### PR TITLE
add oipa url as setting + top 5 countries homepage changes

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -18,6 +18,8 @@ require_relative 'helpers/sector_helpers.rb'
 #helpers modules
 include SectorHelpers
 
+# set global settings
+set :oipa_api_url, 'http://dfid-oipa.zz-clients.net/api/'
 
 #ensures that we can use the extension html.erb rather than just .erb
 Tilt.register Tilt::ERBTemplate, 'html.erb'
@@ -32,7 +34,7 @@ get '/' do  #homepage
 	top5sectors = JSON.parse(File.read('data/top5sectors.json'))
 	top5results = JSON.parse(File.read('data/top5results.json'))
 
-	countriesJSON = RestClient.get "http://dfid-oipa.zz-clients.net/api/activities/aggregations?reporting_organisation=GB-1&group_by=recipient_country&aggregations=budget&order_by=-budget"
+	countriesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations?reporting_organisation=GB-1&group_by=recipient_country&aggregations=budget&budget_period_start=2015-04-01&budget_period_end=2016-03-31&order_by=-budget&page_size=5"
   	top5countries = JSON.parse(countriesJSON)
 
  	erb :index, 
@@ -55,7 +57,7 @@ end
 # Project summary page
 get '/projects/:proj_id/?' do |n|
 	# get the project data from the API
-	oipa = RestClient.get "http://149.210.176.175/api/activities/#{n}?format=json"
+	oipa = RestClient.get settings.oipa_api_url + "activities/#{n}?format=json"
   	project = JSON.parse(oipa)
 	
 	erb :'projects/summary', 
@@ -68,7 +70,7 @@ end
 #Project test page
 get '/projects/:proj_id/test/?' do |n|
 	# get the project data from the API
-	oipa = RestClient.get "http://149.210.176.175/api/activities/#{n}?format=json"
+	oipa = RestClient.get settings.oipa_api_url + "activities/#{n}?format=json"
   	project = JSON.parse(oipa)
 	
 	erb :'projects/test', 
@@ -81,7 +83,7 @@ end
 #Project documents page
 get '/projects/:proj_id/documents/?' do |n|
 	# get the project data from the API
-	oipa = RestClient.get "http://149.210.176.175/api/activities/#{n}?format=json"
+	oipa = RestClient.get settings.oipa_api_url + "activities/#{n}?format=json"
   	project = JSON.parse(oipa)
 
 	erb :'projects/documents', 
@@ -94,11 +96,11 @@ end
 #Project transactions page
 get '/projects/:proj_id/transactions/?' do |n|
 	# get the project data from the API
-	oipa = RestClient.get "http://149.210.176.175/api/activities/#{n}?format=json"
+	oipa = RestClient.get settings.oipa_api_url + "activities/#{n}?format=json"
   	project = JSON.parse(oipa)
 
 	# get the transactions from the API
-	oipa_tx = RestClient.get "http://149.210.176.175/api/activities/#{n}/transactions?format=json" #TEST: for Partner Project
+	oipa_tx = RestClient.get settings.oipa_api_url + "activities/#{n}/transactions?format=json" #TEST: for Partner Project
   	tx = JSON.parse(oipa_tx)
   	transactions = tx['results']
 
@@ -113,11 +115,11 @@ end
 #Project transactions page (test)
 get '/projects/:proj_id/txtest/?' do |n|
 	# get the project data from the API
-	oipa = RestClient.get "http://149.210.176.175/api/activities/#{n}?format=json"
+	oipa = RestClient.get settings.oipa_api_url + "activities/#{n}?format=json"
   	project = JSON.parse(oipa)
 
 	# get the transactions from the API
-	oipa_tx = RestClient.get "http://149.210.176.175/api/activities/#{n}-101/transactions?format=json" #TEST: hard-coding -101
+	oipa_tx = RestClient.get settings.oipa_api_url + "activities/#{n}-101/transactions?format=json" #TEST: hard-coding -101
   	tx = JSON.parse(oipa_tx)
   	transactions = tx['results']
 

--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -83,8 +83,8 @@ layout: landing
         <ol>
         <% top_5_countries.each do |country| %>
           <li>
-             <!-- <a href="/countries/<%= country['code'] %>" class="truncate" title="<%= country['name'] %>"> <%= country['name'] %> </a> -->
-              <em><span class="visually-hidden">Budget</span><%= format_billion_stg country['budget'] %></em>
+             <a href="/countries/<%= country['recipient_country']['code'] %>" class="truncate" title="<%= country['recipient_country']['name'] %>"> <%= country['recipient_country']['name'] %> </a>
+              <em><span class="visually-hidden">Budget</span><%= format_million_stg country['budget'] %></em>
           </li>
         <% end %>
         </ol>


### PR DESCRIPTION
Hi Devtracker team,

I just got Devtracker running on one of our servers, just to check how that works. While checking how to run a Sinatra app I looked through the code and made some minor adjustments:

-Added a setting for the OIPA API URL, so you'll only have to change it in 1 place when we move to another URL. 

-Updated the top 5 countries call (only FY15/16, and only get the first 5) and changed some attributes to make the name + link to the country work.
