### PR TITLE
Build country summary page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem 'activesupport'
 gem 'rack-test'
 gem 'rake-compiler'
 gem 'coveralls', require: false
+gem 'kramdown'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
+    kramdown (1.8.0)
     mime-types (2.6.1)
     minitest (5.7.0)
     money (6.6.1)
@@ -68,6 +69,7 @@ DEPENDENCIES
   bundler
   coveralls
   json
+  kramdown
   money
   rack-test
   rake-compiler

--- a/data/countryInfo.json
+++ b/data/countryInfo.json
@@ -1,0 +1,25 @@
+[
+	{
+		"name": "Pakistan",
+		"code": "PK",
+		"description": "Approximately 66 million Pakistanis live in poverty and 12 million children are out of school. One in 11 children die before their fifth birthday and 12,000 women die in childbirth every year. The population is set to rise by 50% in less than 40 years. UK development spend in Pakistan is an investment in a more prosperous, more stable country which will not only help millions of poor Pakistanis, but will also improve stability and security in the region, and beyond.\n\n## Top priorities\n* creating jobs and supporting economic growth\n* increasing access to and quality of education\n* women and children's health\n* strengthening democracy and governance\n* building peace and stability\n\n## Further resources\n\n[DFID Operational Plan for Pakistan](https://www.gov.uk/government/publications/dfid-pakistan-operational-plan-2014)\n\n [Pakistan page on GOV.UK website](https://www.gov.uk/government/world/pakistan)",
+		"population": 173150000,
+		"belowPovertyLine": 21,
+		"fertilityRate": 3.65,
+		"gdpGrowthRate": 6.07,
+		"projectsCount": 71,
+		"resultsCount": 10
+	},
+	{
+		"name": "Bangladesh",
+		"code": "BD",
+		"description": "Some 60 million people (one in three) live in poverty. Half of all adults, and two out of every three women, are illiterate. One in 11 children die before their fifth birthday, and 12,000 women die in childbirth every year. Nearly half of children under five suffer from stunted growth, which affects brain development and so reduces their ability to learn at school. And Pakistan has had to deal with repeated crises, including floods in 2010 and 2011, and the current economic difficulties.  Entrenched poverty is denying opportunities to millions of people and undermining Pakistan's long term stability and prosperity. Tackling poverty and building a prosperous democratic Pakistan will help not only millions of poor Pakistanis, but will also improve stability in Pakistan, the region, and beyond.  That is why Pakistan is one of the UK Government's top priorities.\n\n## UK aid is helping Pakistan to:\n\n- Transform education - by supporting four million children in school, training 45,000 teachers, and help build 20,000 new classrooms;\n- Support economic stability - by helping 1.23 million people (half of them women) to access microfinance to set up their own small business and by providing vocational skills training to at least 40,000 people;\n- Save women and babies lives – the UK will prevent 3,600 mothers' deaths in childbirth and help half-a-million couples access family planning and contraception;\n- Build peace, stability, and democracy - for example, by helping another two million people (half of them women) to vote at the next general election;\"\n\nThe UK will continue to provide humanitarian assistance and rebuild schools, roads, and bridges when needed, as it did in response to the devastating floods in 2010, the earthquake in 2005, and ongoing conflict in the region bordering Afghanistan.\n\nThe UK has deep family, historic, and business ties with Pakistan. That's why we are committed to Pakistan for the long-term, to help millions of people lift themselves out of poverty, and to help Pakistan to become the stable, prosperous, democratic country it has the potential to be.\n\nIncreased aid to Pakistan is dependent on securing value for money and results, and will be linked to progress on reform, as the Government of Pakistan takes steps to build a more dynamic economy, strengthen the tax base, and tackle corruption.",
+		"population": 173150000,
+		"belowPovertyLine": 21,
+		"fertilityRate": 3.65,
+		"gdpGrowthRate": 6.07,
+		"projectsCount": 71,
+		"resultsCount": 10
+	}
+	
+]

--- a/devtracker.rb
+++ b/devtracker.rb
@@ -191,7 +191,7 @@ get '/projects/:proj_id/partners/?' do |n|
  			fundedProjects: fundedProjectsData['results'],
  			fundedProjectsCount: fundedProjectsData['count']  
  		}
-
+end
 #####################################################################
 #  STATIC PAGES
 #####################################################################

--- a/devtracker.rb
+++ b/devtracker.rb
@@ -6,6 +6,7 @@ require 'sinatra'
 require 'json'
 require 'rest-client'
 require 'active_support'
+require 'kramdown'
 
 #helpers
 require_relative 'helpers/formatters.rb'
@@ -13,9 +14,17 @@ require_relative 'helpers/oipa_helpers.rb'
 require_relative 'helpers/codelists.rb'
 require_relative 'helpers/lookups.rb'
 require_relative 'helpers/project_helpers.rb'
+require_relative 'helpers/country_helpers.rb'
+
+#Helper Modules
+include CountryHelpers
+include Formatters
 
 #ensures that we can use the extension html.erb rather than just .erb
 Tilt.register Tilt::ERBTemplate, 'html.erb'
+#####################################################################
+#  Common Variable Assingment
+#####################################################################
 
 #####################################################################
 #  HOME PAGE
@@ -37,9 +46,60 @@ get '/' do  #homepage
 end
 
 #####################################################################
+#  COUNTRY PAGES
+#####################################################################
+countriesInfo = JSON.parse(File.read('data/countryInfo.json'))
+
+# Country summary page
+get '/countries/:country_code/?' do |n|
+	current_first_day_of_financial_year = first_day_of_financial_year(DateTime.now)
+	current_last_day_of_financial_year = last_day_of_financial_year(DateTime.now)
+    country = countriesInfo.select {|country| country['code'] == n}.first
+    oipa_total_projects = RestClient.get "http://dfid-oipa.zz-clients.net/api/activities?reporting_organisation=GB-1&hierarchy=1&related_activity_recipient_country=#{n}&format=json"
+    total_projects = JSON.parse(oipa_total_projects)
+    oipa_active_projects = RestClient.get "http://dfid-oipa.zz-clients.net/api/activities?reporting_organisation=GB-1&hierarchy=1&related_activity_recipient_country=#{n}&activity_status=2&format=json"
+    active_projects = JSON.parse(oipa_active_projects)
+    oipa_total_project_budgets = RestClient.get "http://dfid-oipa.zz-clients.net/api/activities/aggregations?format=json&reporting_organisation=GB-1&budget_period_start=#{current_first_day_of_financial_year}&budget_period_end=#{current_last_day_of_financial_year}&group_by=recipient_country&aggregations=budget&recipient_country=#{n}"
+    total_project_budgets= JSON.parse(oipa_total_project_budgets)
+    oipa_year_wise_budgets=RestClient.get "http://dfid-oipa.zz-clients.net/api/activities/aggregations?format=json&reporting_organisation=GB-1&group_by=budget_per_quarter&aggregations=budget&recipient_country=#{n}&order_by=year,quarter"
+    year_wise_budgets= JSON.parse(oipa_year_wise_budgets)
+
+	# get the project data from the API
+	#oipa = RestClient.get "http://149.210.176.175/api/activities/#{n}?format=json"
+  	#project = JSON.parse(oipa)
+	
+	erb :'countries/country', 
+		:layout => :'layouts/layout',
+		:locals => {
+ 			country: country,
+ 			total_projects: total_projects,
+ 			active_projects: active_projects,
+ 			total_project_budgets: total_project_budgets,
+ 			year_wise_budgets: year_wise_budgets
+ 		}
+end
+
+#Country Project List Page
+get '/countries/:country_code/projects/?' do |n|
+	#countriesInfo.select {|country| country['code'] == n}.each do |country|		
+		country=countriesInfo.select {|country| country['code'] == n}.first
+		oipa_total_projects = RestClient.get "http://dfid-oipa.zz-clients.net/api/activities?reporting_organisation=GB-1&hierarchy=1&related_activity_recipient_country=#{n}&format=json"
+	    total_projects = JSON.parse(oipa_total_projects)
+		oipa_project_list = RestClient.get "http://dfid-oipa.zz-clients.net/api/activities?format=json&reporting_organisation=GB-1&hierarchy=1&related_activity_recipient_country=#{n}&fields=title,descriptions,activity_status,reporting_organisation,iati_identifier,total_child_budgets,participating_organisations,activity_dates&page_size=1000"
+		projects_list= JSON.parse(oipa_project_list)
+		projects = projects_list['results']
+		erb :'countries/projects', 
+			:layout => :'layouts/layout',
+			:locals => {
+		 		country: country,
+		 		total_projects: total_projects,
+		 		projects: projects
+		 		}
+		 			
+end
+#####################################################################
 #  PROJECTS PAGES
 #####################################################################
-
 # examples:
 #http://devtracker.dfid.gov.uk/projects/GB-1-204024/
 # http://149.210.176.175/api/activities/GB-1-204024?format=json
@@ -51,19 +111,6 @@ get '/projects/:proj_id/?' do |n|
   	project = JSON.parse(oipa)
 	
 	erb :'projects/summary', 
-		:layout => :'layouts/layout',
-		 :locals => {
- 			project: project
- 		}
-end
-
-#Project test page
-get '/projects/:proj_id/test/?' do |n|
-	# get the project data from the API
-	oipa = RestClient.get "http://149.210.176.175/api/activities/#{n}?format=json"
-  	project = JSON.parse(oipa)
-	
-	erb :'projects/test', 
 		:layout => :'layouts/layout',
 		 :locals => {
  			project: project
@@ -102,28 +149,23 @@ get '/projects/:proj_id/transactions/?' do |n|
  		}
 end
 
-#Project transactions page (test)
-get '/projects/:proj_id/txtest/?' do |n|
-	# get the project data from the API
-	oipa = RestClient.get "http://149.210.176.175/api/activities/#{n}?format=json"
-  	project = JSON.parse(oipa)
-
-	# get the transactions from the API
-	oipa_tx = RestClient.get "http://149.210.176.175/api/activities/#{n}-101/transactions?format=json" #TEST: hard-coding -101
-  	tx = JSON.parse(oipa_tx)
-  	transactions = tx['results']
-
-	erb :'projects/testtx', 
-		:layout => :'layouts/layout',
-		:locals => {
-			project: project,
- 			transactions: transactions
- 		}
-end
-
 #####################################################################
 #  STATIC PAGES
 #####################################################################
+
+#Aid By Location Page
+get '/location/country/?' do
+	current_first_day_of_financial_year = first_day_of_financial_year(DateTime.now)
+	current_last_day_of_financial_year = last_day_of_financial_year(DateTime.now)
+	oipa_countries = RestClient.get "http://dfid-oipa.zz-clients.net/api/activities/aggregations?format=json&reporting_organisation=GB-1&budget_period_start=#{current_first_day_of_financial_year}&budget_period_end=#{current_last_day_of_financial_year}&group_by=recipient_country&aggregations=count,budget&order_by=recipient_country"
+  	countries = JSON.parse(oipa_countries)
+
+	erb :'location/country/index', 
+		:layout => :'layouts/layout',
+		:locals => {
+			:countries => countries
+		}
+end
 
 get '/about/?' do
 	erb :'about/index', :layout => :'layouts/layout'

--- a/helpers/formatters.rb
+++ b/helpers/formatters.rb
@@ -20,9 +20,9 @@ module Formatters
     "&pound;#{(v/1000000000.0).round(2)}bn"
   end
 
-  # def markdown_to_html(md)
-  #   Kramdown::Document.new(md || '').to_html
-  # end
+  def markdown_to_html(md)
+    Kramdown::Document.new(md || '').to_html
+  end
 
   def current_financial_year
     now = Time.new
@@ -50,19 +50,19 @@ module Formatters
      URI.escape(s)
   end
 
-  def financial_year_formatter(d)
+  def financial_year_formatter(y)
 
-      date = if(d.kind_of?(String)) then
-        Date.parse d
-      else
-        d
-      end
+      #date = if(d.kind_of?(String)) then
+        #Date.parse d
+      #else
+        #d
+      #end
 
-      if date.month < 4
-        "FY#{(date.year-1).to_s[2..3]}/#{date.year.to_s[2..3]}"
-      else
-        "FY#{date.year.to_s[2..3]}/#{(date.year+1).to_s[2..3]}"
-      end
+      #if date.month < 4
+        #{}"FY#{(date.year-1).to_s[2..3]}/#{date.year.to_s[2..3]}"
+      #else
+        "FY#{y.to_s[2..3]}/#{(y+1).to_s[2..3]}"
+      #end
     end
 
   def financial_year 

--- a/helpers/project_helpers.rb
+++ b/helpers/project_helpers.rb
@@ -274,13 +274,20 @@ module ProjectHelpers
         @cms_db['documents'].find({ 'project' => projectCode}).count
     end
 
-private
 
     def first_day_of_financial_year(date_value)
         if date_value.month > 3 then
             Date.new(date_value.year, 4, 1)
         else
             Date.new(date_value.year - 1, 4, 1)
+        end
+    end
+
+    def last_day_of_financial_year(date_value)
+        if date_value.month > 3 then
+            Date.new(date_value.year + 1, 3, 31)
+        else
+            Date.new(date_value.year, 3, 31)
         end
     end 
 

--- a/views/countries/country.html.erb
+++ b/views/countries/country.html.erb
@@ -1,6 +1,5 @@
----
-title: Development Tracker
----
+
+
 
 <div id="page-title" class="row">
     <div class="twelve columns">
@@ -14,24 +13,24 @@ title: Development Tracker
                 </ul>
             </div>
             <h1>
-                <img src="/images/flags/<%=h country['code'].downcase%>.png" alt="Country Flag"><%=h country['name'] %></small>
+                <img src="/images/flags/<%= country['code'].downcase%>.png" alt="Country Flag"><%= country['name'] %></small>
             </h1>
         </div>
     </div>
 </div>
 
-<%= partial "partials/countries-tabs", :locals => { :active => "summary", :country => country, :project_count => projects.size, :results_count => results.size } %>
+<%= erb :'partials/_countries-tabs', :locals => { :active => "summary", :country => country, :project_count => total_projects['count'], :results_count => country['resultsCount'] } %>
 
 <div class="row">
     <div class="twelve columns summary">
         <h2 class="visually-hidden">Summary</h2>
-        <div class="description"><%= markdown_to_html(h country['description'])%></div>
+        <div class="description"><%= markdown_to_html(country['description'])%></div>
         <script type="text/javascript">
             $('div.description').expander({
                 slicePoint    : 300,
                 expandSpeed   : 0,
                 collapseSpeed : 0,
-                expandText    : 'Read more about <%=h country["name"] %>' 
+                expandText    : 'Read more about <%=country['name'] %>' 
             });
         </script>
     </div>
@@ -41,9 +40,9 @@ title: Development Tracker
     <div class="six columns">
         <h3>Key Info</h3>
         <ul class="info-list vertical">
-            <% if country_organisation_plan!= nil then %>
-                <li class="fact-item">
-                Operational Plan Budget <strong><%= current_financial_year %></strong>
+            <%# if country_organisation_plan!= nil then %>
+                <!--<li class="fact-item">
+                Operational Plan Budget <strong><%#= current_financial_year %></strong>
                 <a class="more-info-link more-info-link-spacer" id="moreinfolink1" target="1">
                     <img src="/images/icon-information.png" alt="More information about the operational plan budget"/>
                 </a>
@@ -52,12 +51,12 @@ title: Development Tracker
                        This is the figure quoted in the Country's Operational Plan that we plan to spend in the current financial year.
                     </div>
                 </aside>
-                <span><strong><%= number_to_currency(country_organisation_plan['operationalBudget'], :unit=>"£", :precision => 0) %></strong></span>
-                </li>
-            <% end %>
+                <span><strong><%#= number_to_currency(country_organisation_plan['operationalBudget'], :unit=>"£", :precision => 0) %></strong></span>
+                </li>-->
+            <%# end %>
             <li class="fact-item">
                 Total Project Budget for <strong><%= current_financial_year %></strong>
-                <a class="more-info-link more-info-link-spacer" id="moreinfolink1" target="1">
+                <a class="more-info-link more-info-link-spacer" id="moreinfolink1" target="2">
                     <img src="/images/icon-information.png" alt="More information about the total project budget"/>
                 </a>
                 <aside id="moreinfo1" class="more-info">            
@@ -65,15 +64,15 @@ title: Development Tracker
                        Project budget to date. Some values may not be included if projects are in an active procurement phase, so this figure will change over time.
                     </div>
                 </aside>
-                <span><strong><%= number_to_currency(stats['totalBudget'], :unit=>"£", :precision => 0) %></strong></span>
+                <span><strong><%= total_project_budgets[0]['budget'].to_f.round(0)%></strong></span>
             </li>
-            <li class="fact-item">
+            <!--<li class="fact-item">
                 Project budget as % of DFID budget
-                <span><strong><%= (stats['totalBudget']/(dfid_total_budget.nonzero? || 1) * 100).round(2) || "&nbsp;" %>%</strong></span>
-            </li>
+                <span><strong><%#= (stats['totalBudget']/(dfid_total_budget.nonzero? || 1) * 100).round(2) || "&nbsp;" %>%</strong></span>
+            </li>-->
             <li class="fact-item">
                 Active Projects
-                <span><strong><%= active_projects country['code'] || "&nbsp;" %></strong></span>
+                <span><strong><%= active_projects['count'] || "&nbsp;" %></strong></span>
             </li>
             <% if country['population'] then %>
                 <li class="fact-item">
@@ -105,8 +104,8 @@ title: Development Tracker
     <div class="six columns" role="presentation">
         <div id="countryMap" class="countryMap"></div>
 
-        <input type="hidden" id="countryName" value="<%=h country['name'] %>">
-        <input type="hidden" id="countryCode" value="<%=h country['code'] %>">
+        <input type="hidden" id="countryName" value="<%=country['name'] %>">
+        <input type="hidden" id="countryCode" value="<%=country['code'] %>">
        
         <div id="countryMapDisclaimer" class="disclaimer grey">
             <p><strong>Disclaimer</strong>: Country borders do not necessarily reflect the UK Government's official position.</p>
@@ -133,13 +132,13 @@ title: Development Tracker
             <div class="six columns">
                 <div id="sectorLegend">
                     <ul class="legend-list">
-                        <% (sector_groups country['code']).each do |sector| %>
+                        <%# (sector_groups country['code']).each do |sector| %>
                             <li><span class="theme-1 legend-color"></span>
-                                <div title="<%=sector['name'] || "Other"%>" style="white-space: nowrap; text-overflow: ellipsis; overflow: hidden;">
-                                <%=sector['name'] || "Other"%></div>
-                                <em><%= sector['percentage'] %><span class="visually-hidden">projects</span></em>
+                                <div title="<%#=sector['name'] || "Other"%>" style="white-space: nowrap; text-overflow: ellipsis; overflow: hidden;">
+                                <%#=sector['name'] || "Other"%></div>
+                                <em><%#= sector['percentage'] %><span class="visually-hidden">projects</span></em>
                             </li>
-                        <% end %>
+                        <%# end %>
                     </ul>
                 </div>
             </div>
@@ -155,8 +154,8 @@ title: Development Tracker
                         The aggregated project budget where that country has been identifed as having money spent specifically in it. 
                     </div>
             </aside>
-         </div> 
-         <div id="budget-year-chart" style="height: 250px;" class="standard">
+         </div>
+        <div id="budget-year-chart" style="height: 250px;" class="standard">
         </div>
     </div>
 </div>
@@ -174,12 +173,12 @@ title: Development Tracker
  <script>
  
      (function(){
-        var budgets = <%= ([["Year", "Budget"]]) + (country_project_budgets country['code'])%>
-        ;
+        var budgets =<%= ([["Year", "Budget"]]) + (country_project_budgets year_wise_budgets)%>;
+        //alert(budgets);
 
         charts.bar("#budget-year-chart", budgets, ".2s", null, null, ["#D8DCBF"]);
 
-        var sectors = <%= (sector_groups country['code']).to_json %>
+        /*var sectors = "Health"//<%#= (sector_groups country[1]).to_json %>
                 charts.donut("#sectorChart", sectors, function(d) {
                   return d.total;
                 }, function(d){
@@ -188,7 +187,7 @@ title: Development Tracker
                   return d.percentage;
                 });
 
-        charts.donutLegend("#sectorLegend", ".legend-color", 14, sectors, function(d){ return d.name });
+        charts.donutLegend("#sectorLegend", ".legend-color", 14, sectors, function(d){ return d.name });*/
      
          })()
  
@@ -202,7 +201,7 @@ title: Development Tracker
 
 <script type="text/javascript">
     var mapType = "country";
-    var locations = <%=locations.to_json%>
+    var locations = <%#=locations.to_json%>
 </script>
 <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
 <script src="/javascripts/leaflet/countryBounds.js" type="text/javascript"></script>

--- a/views/countries/projects.html.erb
+++ b/views/countries/projects.html.erb
@@ -1,6 +1,3 @@
----
-title: Development Tracker
----
 
 <div id="page-title" class="row">
     <div class="twelve columns">
@@ -20,7 +17,12 @@ title: Development Tracker
     </div>
 </div>
 
-<%= partial "partials/countries-tabs", :locals => { :active => "projects", :country => country, :project_count => projects.size, :results_count => results.size } %>
-
-
-<%= partial "partials/project_list", :locals => { :projects => projects } %>
+<%= erb :'partials/_countries-tabs', :locals => { :active => "projects", :country => country, :project_count => total_projects['count'], :results_count => country['resultsCount'] } %>
+<%#=projects.size%>
+<%# projects.each do |project| %>
+    <%#= project['iati_identifier'] %>
+    <%#= project['title']['narratives'][0]['text'] %>
+    <%#=project['reporting_organisation']['organisation']['name']['narratives'][0]['text']%>
+    <%#=project['activity_status']['name']%>
+<%# end %>
+<%= erb :'partials/_project_list', :locals => { :projects => projects } %>

--- a/views/location/country/index.html.erb
+++ b/views/location/country/index.html.erb
@@ -1,9 +1,6 @@
----
-title: Development Tracker
----
 
-<%= partial "partials/location-title-bar" %>
-<%= partial "partials/location-tabs", :locals => { :active => "country" }  %>
+<%= erb :'partials/_location-title-bar'%>
+<%= erb :'partials/_location-tabs', :locals => { :active => "country" } %>
 
 <!--[if lte IE 8]>
     <div class="row">
@@ -17,7 +14,7 @@ title: Development Tracker
         <div class="row">
             <div class="twelve columns map">
                 <script type="text/javascript">
-                    var countriesData = <%= dfid_country_projects_data %>;
+                    
                 </script>
 
                 <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
@@ -51,8 +48,8 @@ title: Development Tracker
 </div>
 <div class="row">
   <div class="twelve columns">
-    <% country_list.each do |country| %>
-      <a href="/countries/<%=country['code']%>"><%= country['name'] %></a> | 
+    <% countries.each do |country| %>
+      <a href="/countries/<%=country['recipient_country']['code']%>"><%= country['recipient_country']['name'] %></a> | 
     <% end %>
   </div>
 </div> 

--- a/views/partials/_countries-tabs.html.erb
+++ b/views/partials/_countries-tabs.html.erb
@@ -8,7 +8,7 @@
                         <ul class="tab-bar">
                             <li <%= active=="summary" ? "class='active'" : ""%>><a href="/countries/<%= country['code'] %>">Summary</a></li>
                             <li <%= active=="projects" ? "class='active'" : ""%>><a href="/countries/<%= country['code'] %>/projects">All Projects (<%=project_count%>)</a></li>
-                            <% if (results_count > 0) %>
+                            <%if results_count > 0 %>
                             <li <%= active=="results" ? "class='active'" : ""%>><a href="/countries/<%= country['code'] %>/results">Results</a></li>
                             <% end %>
                         </ul>
@@ -16,7 +16,7 @@
                 </div>  
 
                  <div class="button-row">
-                    <% if (project_count > 0) %>
+                    <% if project_count > 0 %>
                     <span>
                         <a href="https://public.govdelivery.com/accounts/UKDFID/subscriber/new?topic_id=UKDFID_<%= format_query_string country['code'] %>" title="Subscribe to receive updates on <%= country['name'] %> by email" class="button inform">&#9993; Subscribe</a>
                     </span>

--- a/views/partials/_location-title-bar.html.erb
+++ b/views/partials/_location-title-bar.html.erb
@@ -4,7 +4,7 @@
         <div>
             <div class="breadcrumb">
                 <ul>
-                    <li><a href="/index.html">Home</a></li>
+                    <li><a href="/">Home</a></li>
                     <li>Aid by Location</li>
                 </ul>
             </div>

--- a/views/partials/_project_list.html.erb
+++ b/views/partials/_project_list.html.erb
@@ -24,31 +24,31 @@
         </div>
         <% projects.each do |project| %>
             <div class="search-result">
-                <input type="hidden" name="status" value="<%= activity_status(project['status']) %>"/>
-                <input type="hidden" name="budget" value="<%= project['totalBudget'] %>"  class="sort-budget"/>
-                <input type="hidden" name="title" value="<%= project['title'] %>" class="sort-title"/>
-                <input type="hidden" name="sectors" value="<%=retrieve_high_level_sector_names(project["iatiId"])%>"/>
-                <input type="hidden" name="organizations" value="<%=project['participatingOrgs'].join('#')%>" />
-                <% if project['projectType'] == "country" %>
-                    <input type="hidden" name="countries" value="<%=country_name project['recipient']%>" />
-                <% end %>
-                <% if project['projectType'] == "regional" %>
-                    <input type="hidden" name="regions" value="<%=region_name project['recipient']%>"  />
-                <% end %>
-                <input type="hidden" name="organizations" value="<%=project['participatingOrgs'].join('#')%>" />
-                <input type="hidden" name="documents" value="<% if(project['documents'] != nil) then result = ""; project['documents'].each do |d| d['categories'].each do |c| result += c.strip + '#' end;
-                                            end; result = result.chop!; %><%= result %><% end%>" />
-                <input type="hidden" name="dateStart" value="<%= choose_better_date(project['start-actual'], project['start-planned']) %>"/>
-                <input type="hidden" name="dateEnd" value="<%= choose_better_date(project['end-actual'], project['end-planned']) %>"/>
+                <input type="hidden" name="status" value="<%= project['activity_status']['name'] %>"/>
+                <input type="hidden" name="budget" value="<%#= project['totalBudget'] %>"  class="sort-budget"/>
+                <input type="hidden" name="title" value="<%= project['title']['narratives'][0]['text'] %>" class="sort-title"/>
+                <input type="hidden" name="sectors" value="<%#=retrieve_high_level_sector_names(project["iatiId"])%>"/>
+                <input type="hidden" name="organizations" value="<%# project['participating_organisations'].each do |p| result +=p['organisation']['name']['narratives'][0]['text'].strip + '#' end; result = result.chop!; %><%#= result %><%#=project['participatingOrgs'].join('#')%>" />
+                <%# if project['projectType'] == "country" %>
+                    <input type="hidden" name="countries" value="<%#=country_name project['recipient']%>" />
+                <%# end %>
+                <%# if project['projectType'] == "regional" %>
+                    <input type="hidden" name="regions" value="<%#=region_name project['recipient']%>"  />
+                <%# end %>
+                <input type="hidden" name="organizations" value="<%# project['participating_organisations'].each do |p| result +=p['organisation']['name']['narratives'][0]['text'].strip + '#' end; result = result.chop!; %><%#= result %><%#=project['participatingOrgs'].join('#')%>" />
+                <input type="hidden" name="documents" value="<%# if(project['documents'] != nil) then result = ""; project['documents'].each do |d| d['categories'].each do |c| result += c.strip + '#' end;
+                                            end; result = result.chop!; %><%#= result %><%# end%>" />
+                <input type="hidden" name="dateStart" value="<%= choose_better_date(project['activity_dates']['start_actual'], project['activity_dates']['start_planned']) %>"/>
+                <input type="hidden" name="dateEnd" value="<%= choose_better_date(project['activity_dates']['end_actual'], project['activity_dates']['end_planned']) %>"/>
                 <h3>
-                    <a href="/projects/<%=project['iatiId']%>">
-                        <%=project['title']%> <small>[<%=project['iatiId']%>]</small>
+                    <a href="/projects/<%= project['iati_identifier'] %>">
+                        <%=project['title']['narratives'][0]['text']%> <small>[<%= project['iati_identifier']%>]</small>
                     </a>
                 </h3>
-                <span class="budget">Budget: <em> <%= number_to_currency(project['totalBudget'], :unit=>"£", :precision => 0) %></em></span>
-                <span>Status: <em><%= activity_status project['status']%></em></span>
-                <span>Reporting Org: <em><%= project['reportingOrg']%></em></span>
-                <p class="description"><%=project['description']%></p>
+                <span class="budget">Budget: <em> <%# number_to_currency(project['totalBudget'], :unit=>"£", :precision => 0) %></em></span>
+                <span>Status: <em><%= project['activity_status']['name']%></em></span>
+                <span>Reporting Org: <em><%= project['reporting_organisation']['organisation']['name']['narratives'][0]['text']%></em></span>
+                <p class="description"><%= project['descriptions'][0]['narratives'][0]['text']%></p>
             </div>
         <% end %>
     </div>


### PR DESCRIPTION
1. Add routing for Country Summary,Project List and Aid By Location (Country Tab) Page in devtracker.rb
2. Add Country information with Year Wise Bar Graph in Country Summary Tab excluding Sector wise Graph, Map in leaflet and Operational Plan Budget.
3. Build Project List Page for every Country and Searching can be done through status and activity date. Document Categories, Total Budget and Organizational Search will be done after getting proper call from Z&Z. 
4. Country List has shown in Aid By Location ( Country Tab) Page with Country Code wise ordering. Z&Z will provide Country Name wise ordering. Only Those Country are showing those have more than Zero Active projects. Map will be fixed in next phase