### PR TITLE
Fix document type project document page

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -29,12 +29,12 @@ include ProjectHelpers
 include CommonHelpers
 
 # Developer Machine: set global settings
-set :oipa_api_url, 'http://dfid-oipa.zz-clients.net/api/'
+#set :oipa_api_url, 'http://dfid-oipa.zz-clients.net/api/'
 
 set :current_first_day_of_financial_year, first_day_of_financial_year(DateTime.now)
 set :current_last_day_of_financial_year, last_day_of_financial_year(DateTime.now)
 # Server Machine: set global settings
-#set :oipa_api_url, 'http://127.0.0.1:6081/api/'
+set :oipa_api_url, 'http://127.0.0.1:6081/api/'
 
 #ensures that we can use the extension html.erb rather than just .erb
 Tilt.register Tilt::ERBTemplate, 'html.erb'

--- a/devtracker.rb
+++ b/devtracker.rb
@@ -18,18 +18,23 @@ require_relative 'helpers/lookups.rb'
 require_relative 'helpers/project_helpers.rb'
 require_relative 'helpers/sector_helpers.rb'
 require_relative 'helpers/country_helpers.rb'
+require_relative 'helpers/document_helpers.rb'
+require_relative 'helpers/common_helpers.rb'
 
 #Helper Modules
 include CountryHelpers
 include Formatters
 include SectorHelpers
 include ProjectHelpers
+include CommonHelpers
 
 # Developer Machine: set global settings
-#set :oipa_api_url, 'http://dfid-oipa.zz-clients.net/api/'
+set :oipa_api_url, 'http://dfid-oipa.zz-clients.net/api/'
 
+set :current_first_day_of_financial_year, first_day_of_financial_year(DateTime.now)
+set :current_last_day_of_financial_year, last_day_of_financial_year(DateTime.now)
 # Server Machine: set global settings
-set :oipa_api_url, 'http://127.0.0.1:6081/api/'
+#set :oipa_api_url, 'http://127.0.0.1:6081/api/'
 
 #ensures that we can use the extension html.erb rather than just .erb
 Tilt.register Tilt::ERBTemplate, 'html.erb'
@@ -46,8 +51,10 @@ get '/' do  #homepage
 #	top5countries = JSON.parse(File.read('data/top5countries.json'))
 	top5sectors = JSON.parse(File.read('data/top5sectors.json'))
 	top5results = JSON.parse(File.read('data/top5results.json'))
-
-	countriesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations?reporting_organisation=GB-1&group_by=recipient_country&aggregations=budget&budget_period_start=2015-04-01&budget_period_end=2016-03-31&order_by=-budget&page_size=5"
+	#current_first_day_of_financial_year = first_day_of_financial_year(DateTime.now)
+	#current_last_day_of_financial_year = last_day_of_financial_year(DateTime.now)
+	
+	countriesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations?reporting_organisation=GB-1&group_by=recipient_country&aggregations=budget&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}&order_by=-budget&page_size=5"
   	top5countries = JSON.parse(countriesJSON)
 
  	erb :index, 
@@ -66,14 +73,14 @@ countriesInfo = JSON.parse(File.read('data/countryInfo.json'))
 
 # Country summary page
 get '/countries/:country_code/?' do |n|
-	current_first_day_of_financial_year = first_day_of_financial_year(DateTime.now)
-	current_last_day_of_financial_year = last_day_of_financial_year(DateTime.now)
+	#current_first_day_of_financial_year = first_day_of_financial_year(DateTime.now)
+	#current_last_day_of_financial_year = last_day_of_financial_year(DateTime.now)
     country = countriesInfo.select {|country| country['code'] == n}.first
     oipa_total_projects = RestClient.get settings.oipa_api_url + "activities?reporting_organisation=GB-1&hierarchy=1&related_activity_recipient_country=#{n}&format=json"
     total_projects = JSON.parse(oipa_total_projects)
     oipa_active_projects = RestClient.get settings.oipa_api_url + "activities?reporting_organisation=GB-1&hierarchy=1&related_activity_recipient_country=#{n}&activity_status=2&format=json"
     active_projects = JSON.parse(oipa_active_projects)
-    oipa_total_project_budgets = RestClient.get settings.oipa_api_url + "activities/aggregations?format=json&reporting_organisation=GB-1&budget_period_start=#{current_first_day_of_financial_year}&budget_period_end=#{current_last_day_of_financial_year}&group_by=recipient_country&aggregations=budget&recipient_country=#{n}"
+    oipa_total_project_budgets = RestClient.get settings.oipa_api_url + "activities/aggregations?format=json&reporting_organisation=GB-1&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}&group_by=recipient_country&aggregations=budget&recipient_country=#{n}"
     total_project_budgets= JSON.parse(oipa_total_project_budgets)
     oipa_year_wise_budgets=RestClient.get settings.oipa_api_url + "activities/aggregations?format=json&reporting_organisation=GB-1&group_by=budget_per_quarter&aggregations=budget&recipient_country=#{n}&order_by=year,quarter"
     year_wise_budgets= JSON.parse(oipa_year_wise_budgets)
@@ -160,10 +167,18 @@ get '/projects/:proj_id/transactions/?' do |n|
 	oipa = RestClient.get settings.oipa_api_url + "activities/#{n}?format=json"
   	project = JSON.parse(oipa)
 
-	# get the transactions from the API
-	oipaTransactionsJSON = RestClient.get settings.oipa_api_url + "transactions?format=json&activity_related_activity_id=#{n}&page_size=400" 
+	# get the transactions from the API & get quarterly budget for H1 Activity
+	if is_dfid_project(project['id']) then
+		oipaTransactionsJSON = RestClient.get settings.oipa_api_url + "transactions?format=json&activity_related_activity_id=#{n}&page_size=400&fields=activity,description,provider_organisation_name,provider_activity,receiver_organisation_name,transaction_date,transaction_type,value,currency"
+		oipaYearWiseBudgets=RestClient.get settings.oipa_api_url + "activities/aggregations?format=json&reporting_organisation=GB-1&group_by=budget_per_quarter&aggregations=budget&related_activity_id=#{n}&order_by=year,quarter"
+	else
+		oipaTransactionsJSON = RestClient.get settings.oipa_api_url + "transactions?format=json&activity=#{n}&page_size=400&fields=activity,description,provider_organisation_name,provider_activity,receiver_organisation_name,transaction_date,transaction_type,value,currency"
+		oipaYearWiseBudgets=RestClient.get settings.oipa_api_url + "activities/aggregations?format=json&group_by=budget_per_quarter&aggregations=budget&id=#{n}&order_by=year,quarter"
+	end
+			
   	transactionsJSON = JSON.parse(oipaTransactionsJSON)
-  	transactions = transactionsJSON['results']
+  	transactions = transactionsJSON['results'] 	
+  	yearWiseBudgets= JSON.parse(oipaYearWiseBudgets)
 
   	#get details of H2 Activities from the API
   	oipaH2ActivitiesJSON = RestClient.get settings.oipa_api_url + "activities?format=json&related_activity_id=#{n}&page_size=400"
@@ -179,6 +194,7 @@ get '/projects/:proj_id/transactions/?' do |n|
 		:locals => {
 			project: project,
  			transactions: transactions,
+ 			yearWiseBudgets: yearWiseBudgets,
  			h2Activities: h2Activities, 			
  			fundedProjectsCount: fundedProjectsData['count']  
  		}
@@ -208,9 +224,9 @@ end
 
 #Aid By Location Page
 get '/location/country/?' do
-	current_first_day_of_financial_year = first_day_of_financial_year(DateTime.now)
-	current_last_day_of_financial_year = last_day_of_financial_year(DateTime.now)
-	oipa_countries = RestClient.get settings.oipa_api_url + "activities/aggregations?format=json&reporting_organisation=GB-1&budget_period_start=#{current_first_day_of_financial_year}&budget_period_end=#{current_last_day_of_financial_year}&group_by=recipient_country&aggregations=count,budget&order_by=recipient_country"
+	#current_first_day_of_financial_year = first_day_of_financial_year(DateTime.now)
+	#current_last_day_of_financial_year = last_day_of_financial_year(DateTime.now)
+	oipa_countries = RestClient.get settings.oipa_api_url + "activities/aggregations?format=json&reporting_organisation=GB-1&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}&group_by=recipient_country&aggregations=count,budget&order_by=recipient_country"
   	countries = JSON.parse(oipa_countries)
 
 	erb :'location/country/index', 
@@ -218,6 +234,10 @@ get '/location/country/?' do
 		:locals => {
 			:countries => countries
 		}
+end
+
+get '/department' do
+	erb :'department/index', :layout => :'layouts/layout'
 end
 
 get '/about/?' do

--- a/helpers/codelists.rb
+++ b/helpers/codelists.rb
@@ -69,7 +69,8 @@ module CodeLists
     "application/vnd.ms-excel" => "Excel Spreadsheet",
     "application/octet-stream" => "Binary file",
     "application/pdf" => "PDF Document",
-    "text/html" => "Web Page"
+    "text/html" => "Web Page",
+    "application/vnd.oasis.opendocument.text" => "Open Word Document"
 
   }
 
@@ -298,7 +299,7 @@ module CodeLists
   end
 
   def iati_mime_type(code)
-    @@mime_types[code]
+    @@iati_mime_types[code]
   end
 
   def sector(code)

--- a/helpers/common_helpers.rb
+++ b/helpers/common_helpers.rb
@@ -1,0 +1,90 @@
+module CommonHelpers
+
+	#New One based on API Call
+  def financial_year_wise_budgets(yearWiseBudgets,type)
+
+    projectBudgets = []
+    
+    yearWiseBudgets.each do |y|
+      if y["quarter"]==1
+          p=[y["quarter"],y["budget"],y["year"],y["year"]-1]
+      else
+          p=[y["quarter"],y["budget"],y["year"],y["year"]]
+      end
+      
+      projectBudgets << p        
+    end
+
+    #project_budgets
+    #project_budgets = year_wise_budgets.group_by{|b| b["year"]}.map{|year, budgets|
+        #summedBudgets = budgets.reduce(0) {|memo, budget| memo + budget["budget"]}
+        #[year, summedBudgets]
+        #}.sort
+     
+     finYearWiseBudgets = projectBudgets.group_by{|b| b[3]}.map{|year, budgets|
+        summedBudgets = budgets.reduce(0) {|memo, budget| memo + budget[1]}
+        [year, summedBudgets]
+        }.sort   
+
+    # determine what range to show
+      #current_financial_year = first_day_of_financial_year(DateTime.now)
+      currentFinancialYear = financial_year
+
+    # if range is 6 or less just show it
+    if (type=="C") then
+      range = if finYearWiseBudgets.size < 7 then
+               finYearWiseBudgets
+              # if the last item in the list is less than or equal to 
+              # the current financial year get the last 6
+              elsif finYearWiseBudgets.last.first <= currentFinancialYear
+                finYearWiseBudgets.last(6)
+              # other wise show current FY - 3 years and cuurent FY + 3 years
+              else
+                index_of_now = finYearWiseBudgets.index { |i| i[0] == currentFinancialYear }
+
+                if index_of_now.nil? then
+                  finYearWiseBudgets.last(6)
+                else
+                  finYearWiseBudgets[[index_of_now-3,0].max..index_of_now+2]
+                end
+              end
+
+              # finally convert the range into a label format
+              range.each { |item| 
+                item[0] = financial_year_formatter(item[0]) 
+              }
+    elsif (type=="P") then
+    	finYearWiseBudgets.each { |item| 
+          item[0] = financial_year_formatter(item[0]) 
+        }
+              	          
+    end
+
+  end
+
+  #New One based on API Call
+  def financial_year_formatter(y)
+
+    #date = if(d.kind_of?(String)) then
+      #Date.parse d
+    #else
+      #d
+    #end
+
+    #if date.month < 4
+      #{}"FY#{(date.year-1).to_s[2..3]}/#{date.year.to_s[2..3]}"
+    #else
+      "FY#{y.to_s[2..3]}/#{(y+1).to_s[2..3]}"
+    #end
+  end
+
+  def financial_year 
+    now = Time.new
+    if(now.month < 4)
+      now.year-1
+    else
+      now.year
+    end
+  end
+
+end

--- a/helpers/country_helpers.rb
+++ b/helpers/country_helpers.rb
@@ -75,21 +75,21 @@ module CountryHelpers
   end
 
   #New One based on API Call
-  def country_project_budgets(year_wise_budgets)
+  def country_project_budgets(yearWiseBudgets)
     #projectCodes = @cms_db['projects'].find({
       #{}"projectType" => "country", "recipient" => country_code
       #}, :fields => ["iatiId"]).to_a.map{|b| b["iatiId"]}
     #
-    project_budgets = []
+    projectBudgets = []
     
-    year_wise_budgets.each do |y|
+    yearWiseBudgets.each do |y|
       if y["quarter"]==1
           p=[y["quarter"],y["budget"],y["year"],y["year"]-1]
       else
           p=[y["quarter"],y["budget"],y["year"],y["year"]]
       end
       
-      project_budgets << p        
+      projectBudgets << p        
     end
 
     #project_budgets
@@ -98,30 +98,30 @@ module CountryHelpers
         #[year, summedBudgets]
         #}.sort
      
-     fin_year_wise_budgets = project_budgets.group_by{|b| b[3]}.map{|year, budgets|
+     finYearWiseBudgets = projectBudgets.group_by{|b| b[3]}.map{|year, budgets|
         summedBudgets = budgets.reduce(0) {|memo, budget| memo + budget[1]}
         [year, summedBudgets]
         }.sort   
 
     # determine what range to show
       #current_financial_year = first_day_of_financial_year(DateTime.now)
-      current_financial_year = financial_year
+      currentFinancialYear = financial_year
 
     # if range is 6 or less just show it
-      range = if fin_year_wise_budgets.size < 7 then
-               fin_year_wise_budgets
+      range = if finYearWiseBudgets.size < 7 then
+               finYearWiseBudgets
               # if the last item in the list is less than or equal to 
               # the current financial year get the last 6
-              elsif fin_year_wise_budgets.last.first <= current_financial_year
-                fin_year_wise_budgets.last(6)
+              elsif finYearWiseBudgets.last.first <= currentFinancialYear
+                finYearWiseBudgets.last(6)
               # other wise show current FY - 3 years and cuurent FY + 3 years
               else
-                index_of_now = fin_year_wise_budgets.index { |i| i[0] == current_financial_year }
+                index_of_now = finYearWiseBudgets.index { |i| i[0] == currentFinancialYear }
 
                 if index_of_now.nil? then
-                  fin_year_wise_budgets.last(6)
+                  finYearWiseBudgets.last(6)
                 else
-                  fin_year_wise_budgets[[index_of_now-3,0].max..index_of_now+2]
+                  finYearWiseBudgets[[index_of_now-3,0].max..index_of_now+2]
                 end
               end
 

--- a/helpers/document_helpers.rb
+++ b/helpers/document_helpers.rb
@@ -37,3 +37,21 @@ end
 def getR4DDocsCountNotShowing(output_count)
 		output_count.to_i - 5 
 end
+
+def get_document_category(projectId)
+	oipa = RestClient.get settings.oipa_api_url + "activities/#{projectId}?format=json"
+  	project = JSON.parse(oipa)
+  	documents=project['document_links']
+
+  	if documents.length>0 then
+  		result = "";
+  		documents.each do |document|
+  			if !document['category']['code'].nil? then 
+  				result += document_category(document['category']['code'].to_s.strip) + '#' 
+  			end
+  		end
+  		result = result.chop!
+  	else
+  		result=""
+  	end		
+end

--- a/helpers/project_helpers.rb
+++ b/helpers/project_helpers.rb
@@ -313,15 +313,26 @@ module ProjectHelpers
 
     #New Function for API Based Devtracker
     def h2Activity_title(h2Activities,h2ActivityId)
-        h2Activity = h2Activities.select {|activity| activity['id'] == h2ActivityId}.first
-        h2Activity['title']['narratives'][0]['text']
+        if h2Activities.length>0 then
+            h2Activity = h2Activities.select {|activity| activity['id'] == h2ActivityId}.first
+            h2Activity['title']['narratives'][0]['text']
+        else
+            ""
+        end        
     end
 
     def sum_transaction_value(transactionType)
         summedBudgets = transactionType.reduce(0) {|memo, t| memo + t['value'].to_f}
         
         #total_transaction_value['summedBudgets']
+    end
 
+    def sum_budget_value(projectBudgets)
+        if !projectBudgets.nil? && projectBudgets.length > 0 then
+            summedBudgets = projectBudgets.reduce(0) {|memo, t| memo + t[1].to_f}
+        else
+            summedBudgets =0
+        end    
     end
 
 end

--- a/views/countries/country.html.erb
+++ b/views/countries/country.html.erb
@@ -64,7 +64,7 @@
                        Project budget to date. Some values may not be included if projects are in an active procurement phase, so this figure will change over time.
                     </div>
                 </aside>
-                <span><strong><%= total_project_budgets[0]['budget'].to_f.round(0)%></strong></span>
+                <span><strong><%= Money.new(total_project_budgets[0]['budget'].to_f.round(0)*100, "GBP").format(:no_cents_if_whole => true,:sign_before_symbol => false)%></strong></span>
             </li>
             <!--<li class="fact-item">
                 Project budget as % of DFID budget
@@ -173,7 +173,7 @@
  <script>
  
      (function(){
-        var budgets =<%= ([["Year", "Budget"]]) + (country_project_budgets year_wise_budgets)%>;
+        var budgets =<%= ([["Year", "Budget"]]) + (financial_year_wise_budgets(year_wise_budgets,"C"))%>;
         //alert(budgets);
 
         charts.bar("#budget-year-chart", budgets, ".2s", null, null, ["#D8DCBF"]);

--- a/views/partials/_project_list.html.erb
+++ b/views/partials/_project_list.html.erb
@@ -22,10 +22,10 @@
             <span name="afterFilteringAmount" style="display:inline;"></span>
             <span name="numberofResults" value="@results.size" style="display:inline;"><%=projects.size%></span> results
         </div>
-        <% projects.each do |project| %>
+        <% projects.sort{ |a,b| b['total_child_budgets']  <=> a['total_child_budgets'] }.each do |project| %>
             <div class="search-result">
                 <input type="hidden" name="status" value="<%= project['activity_status']['name'] %>"/>
-                <input type="hidden" name="budget" value="<%#= project['totalBudget'] %>"  class="sort-budget"/>
+                <input type="hidden" name="budget" value="<%= project['total_child_budgets'] %>"  class="sort-budget"/>
                 <input type="hidden" name="title" value="<%= project['title']['narratives'][0]['text'] %>" class="sort-title"/>
                 <input type="hidden" name="sectors" value="<%#=retrieve_high_level_sector_names(project["iatiId"])%>"/>
                 <input type="hidden" name="organizations" value="<%# project['participating_organisations'].each do |p| result +=p['organisation']['name']['narratives'][0]['text'].strip + '#' end; result = result.chop!; %><%#= result %><%#=project['participatingOrgs'].join('#')%>" />
@@ -37,7 +37,7 @@
                 <%# end %>
                 <input type="hidden" name="organizations" value="<%# project['participating_organisations'].each do |p| result +=p['organisation']['name']['narratives'][0]['text'].strip + '#' end; result = result.chop!; %><%#= result %><%#=project['participatingOrgs'].join('#')%>" />
                 <input type="hidden" name="documents" value="<%# if(project['documents'] != nil) then result = ""; project['documents'].each do |d| d['categories'].each do |c| result += c.strip + '#' end;
-                                            end; result = result.chop!; %><%#= result %><%# end%>" />
+                                            end; result = result.chop!; %><%#= get_document_category project['iati_identifier'] %><%# end%>" />
                 <input type="hidden" name="dateStart" value="<%= choose_better_date(project['activity_dates']['start_actual'], project['activity_dates']['start_planned']) %>"/>
                 <input type="hidden" name="dateEnd" value="<%= choose_better_date(project['activity_dates']['end_actual'], project['activity_dates']['end_planned']) %>"/>
                 <h3>
@@ -45,7 +45,7 @@
                         <%=project['title']['narratives'][0]['text']%> <small>[<%= project['iati_identifier']%>]</small>
                     </a>
                 </h3>
-                <span class="budget">Budget: <em> <%# number_to_currency(project['totalBudget'], :unit=>"£", :precision => 0) %></em></span>
+                <span class="budget">Budget: <em> <%= Money.new(project['total_child_budgets'].to_f*100,"GBP").format(:no_cents_if_whole => true,:sign_before_symbol => false) %></em></span>
                 <span>Status: <em><%= project['activity_status']['name']%></em></span>
                 <span>Reporting Org: <em><%= project['reporting_organisation']['organisation']['name']['narratives'][0]['text']%></em></span>
                 <p class="description"><%= project['descriptions'][0]['narratives'][0]['text']%></p>

--- a/views/partials/_projects-header.html.erb
+++ b/views/partials/_projects-header.html.erb
@@ -5,7 +5,9 @@
             <div class="breadcrumb">
                 <ul>
                     <li><a href="/">Home</a></li>
-                    <li><a href="/countries/<%= project['recipient_countries']%>/index.html"><%= project['recipient_countries'] || "" %></a></li>
+                    <%if project['recipient_countries'].length == 1 %>
+                        <li><a href="/countries/<%= project['recipient_countries'][0]['country']['code']%>/"><%= project['recipient_countries'][0]['country']['name'] || "" %></a></li>
+                    <% end %>
                     <li title="<%= project['title']['narratives'][0]['text'] %>"><%= project['title']['narratives'][0]['text'] %></li>
                 </ul>
             </div>

--- a/views/projects/documents.html.erb
+++ b/views/projects/documents.html.erb
@@ -1,9 +1,3 @@
----
-published: "true"
-title: Development Tracker
-
----
-
 <%= erb :'partials/_projects-header', :locals => { :project => project, :fundedProjectsCount => fundedProjectsCount, :active => "documents"} %>
 
 <div class="row">
@@ -26,9 +20,9 @@ title: Development Tracker
                   <tr class="result-list-row">
                       <th scope="row"><a href="<%=document['url']%>"><%= document['title']['narratives'][0]['text'].gsub(/\.[^.]*$/, '') %></a></th>
                       <td scope="col">
-                        <%document['format'].each do |item| %>
-                        <%=item[1]%>
-                        <% end %>
+                        <%#document['format'].each do |item| %>
+                        <%= iati_mime_type document['format']['code'] %>
+                        <%# end %>
                       </td>
                       <td scope="col">
                         <% document['category'].each do |category| %>

--- a/views/projects/transactions.html.erb
+++ b/views/projects/transactions.html.erb
@@ -5,15 +5,59 @@ title: Development Tracker
 <%= erb :'partials/_projects-header', :locals => { :project => project, :fundedProjectsCount => fundedProjectsCount, :active => "transactions"} %>
 
 <%# ------------------------------------------------------------------------ %>
+<%#                       B U D G E T S   T A B L E                          %>
+<%# ------------------------------------------------------------------------ %>
+<div class="row">
+  <div class="twelve columns transactions">
+
+    <div class="section-group-title trans-header-container">
+      <div class="trans-header-left">
+        <span class="trans-type-title">Budget</span>
+        <a class="more-info-link more-info-link-spacer" id="moreinfolink1" target="1">
+           <img src="/images/icon-information.png" alt="More information about budget" class="more-info-link-middle"/>
+        </a> 
+        <aside id="moreinfo1" class="more-info">  
+              <div class="more-info-content trans-more-info-box-limiter">
+                The total amount of money available to spend.  Some budgets may not be shown if projects are in an active procurement phase.
+              </div>
+        </aside>   
+        <p style="margin-bottom:2px;">(Current approved budget)</p>
+       </div>  
+       <% projectBudgets=financial_year_wise_budgets(yearWiseBudgets,"P") %>
+       <% totalProjectBudget=sum_budget_value(projectBudgets).to_f %>
+       <div class="trans-header-right">
+         <div class="<%= totalProjectBudget.round(0) < 0 ? 'negative' : ''%> float-right trans-type-value">
+           <%=  Money.new(totalProjectBudget.round(0)*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false)%>
+         </div>
+       </div>        
+    </div>
+    <table class="transactions-table" style="width:100%">
+      <tbody>
+        <tr>
+          <th>Financial Year</th>
+          <th>Value</th>
+        </tr>
+        <% projectBudgets.each do |projectBudget| %>
+          <tr>
+            <td><%= projectBudget[0] %></td>
+            <td><span class="<%= projectBudget[1].round(0) < 0 ? 'negative' : ''%>"><%= Money.new(projectBudget[1].to_f.round(0)*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %></span></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<%# ------------------------------------------------------------------------ %>
 <%#                   I N C O M I N G   F U N D S   T A B L E                %>
 <%# ------------------------------------------------------------------------ %>
 <div class="row">
   <div class="twelve columns transactions">
     <% #transactions.select {|group| group['transaction_type']['code'] == 'C' }.each do |transaction_group| %>
     <% #transactions.select {|group| group['transaction_type']['code'] == 'D' }.each do |commitment| %>
-    <% incoming_funds=transactions.select {|group| group['transaction_type']['code'] == 'IF' } %>
-    <%if !incoming_funds.nil? && incoming_funds.length > 0 %>
-    <% totalIncomingFund=sum_transaction_value(commitments).to_f %>
+    <% incomingFunds=transactions.select {|group| group['transaction_type']['code'] == 'IF' } %>
+    <%if !incomingFunds.nil? && incomingFunds.length > 0 %>
+    <% totalIncomingFund=sum_transaction_value(incomingFunds).to_f %>
      <div class="section-group-title trans-header-container">
           <div class="trans-header-left">
             <span class="trans-type-title">Incoming Funds</span>
@@ -29,7 +73,7 @@ title: Development Tracker
            </div>  
 
            <div class="trans-header-right">
-             <div class="<%= sum_transaction_value(incoming_funds).to_f < 0 ? 'negative' : ''%> float-right trans-type-value"><%= Money.new(totalIncomingFund*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false)%>
+             <div class="<%= totalIncomingFund.round(0) < 0 ? 'negative' : ''%> float-right trans-type-value"><%= Money.new(totalIncomingFund.round(0)*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false)%>
              </div>
            </div>        
       </div> 
@@ -44,9 +88,10 @@ title: Development Tracker
           <% transactions.select {|group| group['transaction_type']['code'] == 'IF' }.sort{ |a,b| b['transaction_date']  <=> a['transaction_date'] }.each do |incomingFund| %>
             <tr>
               <td><%= incomingFund['description'] %></td>
-              <td width="30%"><%= incomingFund['provider_organisation_name'] + " (" + incomingFund['provider_activity'] + ")" %></td>
+              <td width="30%"><%= incomingFund['provider_organisation_name'] + " (" + 
+              if incomingFund['provider_activity'].nil? then '' else incomingFund['provider_activity'] end + ")" %></td>
               <td width="15%"><%= Date.parse(incomingFund['transaction_date']).strftime("%d %b %Y")%></td>
-              <td width="15%" class="<%= incomingFund['value'].to_f < 0 ? 'negative' : ''%>" style="text-align:right;"><%= Money.new(incomingFund['value'].to_f*100, incomingFund['currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %></td>
+              <td width="15%" class="<%= incomingFund['value'].to_f.round(0) < 0 ? 'negative' : ''%>" style="text-align:right;"><%= Money.new(incomingFund['value'].to_f.round(0)*100, incomingFund['currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %></td>
             </tr>
           <% end %>
         </tbody>
@@ -80,9 +125,9 @@ title: Development Tracker
            </div>  
 
            <div class="trans-header-right">
-             <div class="<%= totalCommitments < 0 ? 'negative' : ''%> float-right trans-type-value">
+             <div class="<%= totalCommitments.round(0) < 0 ? 'negative' : ''%> float-right trans-type-value">
               <%#= number_to_currency(transaction_group["value"].to_f, :unit=> currency_symbol(project['currency']) || "£", :precision => 0)%>
-              <%= Money.new(totalCommitments*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false)%>
+              <%= Money.new(totalCommitments.round(0)*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false)%>
              </div>
            </div>        
       </div> 
@@ -98,9 +143,9 @@ title: Development Tracker
           <%# commitment.sort_by { | tx | -tx['transaction_date'] }.each do |transaction| %>
             <tr>
               <td><%= h2Activity_title(h2Activities,commitment['activity']['id']) %></td>
-              <td width="15%"><%= commitment['activity']['id'] %></td>
+              <td width="15%"><%= is_dfid_project(commitment['activity']['id']) ? commitment['activity']['id'] : ''  %></td>
               <td width="15%"><%= Date.parse(commitment['transaction_date']).strftime("%d %b %Y")%></td>
-              <td width="15%" class="<%= commitment['value'].to_f < 0 ? 'negative' : ''%>" style="text-align:right;"><%= Money.new(commitment['value'].to_f*100, commitment['currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %></td>
+              <td width="15%" class="<%= commitment['value'].to_f.round(0) < 0 ? 'negative' : ''%>" style="text-align:right;"><%= Money.new(commitment['value'].to_f.round(0)*100, commitment['currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %></td>
             </tr>
           <% end %>
         </tbody>
@@ -134,7 +179,7 @@ title: Development Tracker
            </div>  
 
            <div class="trans-header-right">
-             <div class="<%= totalDisbursements < 0 ? 'negative' : ''%> float-right trans-type-value"><%= Money.new(totalDisbursements*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false)%>
+             <div class="<%= totalDisbursements.round(0) < 0 ? 'negative' : ''%> float-right trans-type-value"><%= Money.new(totalDisbursements.round(0)*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false)%>
              </div>
            </div>        
       </div> 
@@ -154,7 +199,7 @@ title: Development Tracker
               <td width="15%"><%= disbursement['receiver_organisation_name'] %></td>
               <td width="15%"><%= disbursement['activity']['id'] %></td>
               <td width="15%"><%= Date.parse(disbursement['transaction_date']).strftime("%d %b %Y")%></td>
-              <td width="15%" class="<%= disbursement['value'].to_f < 0 ? 'negative' : ''%>" style="text-align:right;"><%= Money.new(disbursement['value'].to_f*100, disbursement['currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %></td>
+              <td width="15%" class="<%= disbursement['value'].to_f.round(0) < 0 ? 'negative' : ''%>" style="text-align:right;"><%= Money.new(disbursement['value'].to_f.round(0)*100, disbursement['currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %></td>
             </tr>
           <% end %>
         </tbody>
@@ -188,7 +233,7 @@ title: Development Tracker
            </div>  
 
            <div class="trans-header-right">
-             <div class="<%= totalExpenditures < 0 ? 'negative' : ''%> float-right trans-type-value"><%= Money.new(totalExpenditures*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false)%>
+             <div class="<%= totalExpenditures.round(0) < 0 ? 'negative' : ''%> float-right trans-type-value"><%= Money.new(totalExpenditures.round(0)*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false)%>
              </div>
            </div>        
       </div> 
@@ -206,9 +251,9 @@ title: Development Tracker
             <tr>
               <td><%= expenditure['description'] %></td>
               <td width="15%"><%= expenditure['receiver_organisation_name'] %></td>
-              <td width="15%"><%= expenditure['activity']['id'] %></td>
+              <td width="15%"><%= is_dfid_project(expenditure['activity']['id']) ? expenditure['activity']['id'] : ''%></td>
               <td width="15%"><%= Date.parse(expenditure['transaction_date']).strftime("%d %b %Y")%></td>
-              <td width="15%" class="<%= expenditure['value'].to_f < 0 ? 'negative' : ''%>" style="text-align:right;"><%= Money.new(expenditure['value'].to_f*100, expenditure['currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %></td>
+              <td width="15%" class="<%= expenditure['value'].to_f.round(0) < 0 ? 'negative' : ''%>" style="text-align:right;"><%= Money.new(expenditure['value'].to_f.round(0)*100, expenditure['currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %></td>
             </tr>
           <% end %>
         </tbody>


### PR DESCRIPTION
1. devtracker.rb: Added Transaction and Quaterly Financial budget API Call for Transaction Page for both DFID and Partners Project and set current financial start and end date globally.
2. codelists.rb: add function to identify document mime type.
3. common_helpers.rb: add common functions those can be used to get desired outputs.
4. country_helpers.rb: change variable names to camel case.
5. document_helpers.rb: add function to get document category list for a document.
6. project_helpers.rb: add function to sum budgets for a project and will provide 0 if there is no budget.
7. country.html.erb: formating change on Total Project Budget.
8. _project-list.html.erb: Project Budget added into Project Search list with proper formatting and document type filter option disabled due performance issue.
9. _projects-header.html.erb: Breadcrumb issue fixed for project (specially for Partner Projects)
10. documents.html.erb: Add human readable document type in the page.
11. transactions.html.erb: Budgets and all type of transactions (IF,C,D,E) are generated for both DFID and Partner Projects.