### PR TITLE
Fixed dates on the project summary page 

### DIFF
--- a/helpers/common_helpers.rb
+++ b/helpers/common_helpers.rb
@@ -95,4 +95,44 @@ module CommonHelpers
     end
   end
 
+  def plannedStartDate(dates)
+    begin
+      dates.find do |s|
+        s["type"]["code"].to_s == "1"
+      end["iso_date"]
+    rescue
+      nil
+    end
+  end
+
+  def actualStartDate(dates)
+    begin
+      dates.find do |s|
+        s["type"]["code"].to_s == "2"
+      end["iso_date"]
+    rescue
+      nil
+    end
+  end
+
+  def plannedEndDate(dates)
+    begin
+      dates.find do |s|
+        s["type"]["code"].to_s == "3"
+      end["iso_date"]
+    rescue
+      nil
+    end   
+  end
+
+  def actualEndDate(dates)
+    begin
+      dates.find do |s|
+        s["type"]["code"].to_s == "4"
+      end["iso_date"]
+    rescue
+      nil
+    end
+  end
+
 end

--- a/helpers/project_helpers.rb
+++ b/helpers/project_helpers.rb
@@ -131,6 +131,20 @@ module ProjectHelpers
         return 0
     end
 
+    def choose_better_date_label(actual, planned)
+        # determines project actual start/end date - use actual date, planned date as a fallback
+        unless actual.nil? || actual == ''
+            return "Actual"
+        end
+
+        unless planned.nil? || planned == ''
+            return "Planned"
+        end
+
+        return ""
+    end
+
+
     def project_budgets(projectId)
         project_budgets = @cms_db['project-budgets'].find({
               'id' => projectId

--- a/helpers/project_helpers.rb
+++ b/helpers/project_helpers.rb
@@ -345,7 +345,7 @@ module ProjectHelpers
         if !projectBudgets.nil? && projectBudgets.length > 0 then
             summedBudgets = projectBudgets.reduce(0) {|memo, t| memo + t[1].to_f}
         else
-            summedBudgets =0
+            summedBudgets = 0
         end    
     end
 
@@ -355,11 +355,11 @@ module ProjectHelpers
         #fundingProject = fundingProjectDetails['results'][0]
     end
 
-    def reporting_organisation(org)
+    def reporting_organisation(project)
         begin
-            reporting_organisation = org[0]['narratives'][0]['text']
+            organisation = project['reporting_organisation'][0]['narratives'][0]['text']
         rescue
-            reporting_organisation = org[0]['type']['name']
+            organisation = project['reporting_organisation'][0]['type']['name']
         end
     end
 

--- a/helpers/project_helpers.rb
+++ b/helpers/project_helpers.rb
@@ -355,6 +355,15 @@ module ProjectHelpers
         #fundingProject = fundingProjectDetails['results'][0]
     end
 
+    def reporting_organisation(org)
+        begin
+            reporting_organisation = org[0]['narratives'][0]['text']
+        rescue
+            reporting_organisation = org[0]['type']['name']
+        end
+    end
+
+
 end
 
 helpers ProjectHelpers

--- a/public/stylesheets/aip-styles.css
+++ b/public/stylesheets/aip-styles.css
@@ -100,6 +100,11 @@
 #page-title img + div {
   padding-right: 90px; }
 
+#page-title h2 {
+  font-size: 1.5em;
+  color: #6b6b6b;
+}
+
 .dfid-logo {
   border-left: 3px solid #002878;
   font-size: 1.25em;

--- a/views/partials/_projects-header.html.erb
+++ b/views/partials/_projects-header.html.erb
@@ -14,9 +14,9 @@
             <h1>
                 <%= project['title']['narratives'][0]['text'] %> <small>[<%= project['iati_identifier'] %>]</small>
             </h1>
-            <div>
+            <h2>
                 <%= project['reporting_organisation'][0]['narratives'][0]['text'] || "Department for International Development" %>
-            </div>
+            </h2>
         </div>
     </div>
 </div>

--- a/views/partials/_projects-header.html.erb
+++ b/views/partials/_projects-header.html.erb
@@ -15,7 +15,7 @@
                 <%= project['title']['narratives'][0]['text'] %> <small>[<%= project['iati_identifier'] %>]</small>
             </h1>
             <h2>
-                <%= reporting_organisation(project['reporting_organisation']) %>
+                <%= reporting_organisation(project) %>
              </h2>
         </div>
     </div>

--- a/views/partials/_projects-header.html.erb
+++ b/views/partials/_projects-header.html.erb
@@ -15,8 +15,8 @@
                 <%= project['title']['narratives'][0]['text'] %> <small>[<%= project['iati_identifier'] %>]</small>
             </h1>
             <h2>
-                <%= project['reporting_organisation'][0]['narratives'][0]['text'] || "Department for International Development" %>
-            </h2>
+                <%= reporting_organisation(project['reporting_organisation']) %>
+             </h2>
         </div>
     </div>
 </div>

--- a/views/projects/summary.html.erb
+++ b/views/projects/summary.html.erb
@@ -69,7 +69,6 @@ title: Development Tracker
                         The current stage of the project, consistent with the International Aid Transparency Initiative's (IATI) classifications.
                     </div>
             </aside>
-            <%= actualEndDate(project['activity_dates']) %>
         </div> 
 
 

--- a/views/projects/summary.html.erb
+++ b/views/projects/summary.html.erb
@@ -4,7 +4,6 @@ title: Development Tracker
 
 <%= erb :'partials/_projects-header', :locals => { :project => project, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :active => "summary"} %>
 
-
 <div class="row">
     <div class="twelve columns">
         <% if(non_dfid_data(project['reporting_organisation'][0]['ref'])) %>
@@ -70,6 +69,7 @@ title: Development Tracker
                         The current stage of the project, consistent with the International Aid Transparency Initiative's (IATI) classifications.
                     </div>
             </aside>
+            <%= actualEndDate(project['activity_dates']) %>
         </div> 
 
 
@@ -77,8 +77,8 @@ title: Development Tracker
 
         <!--[if lte IE 8]>
             <div>
-                 <p><strong>Start Date:</strong> <%= format_date(choose_better_date(project['start-actual'], project['start-planned'])) %></p>
-                 <p><strong>End Date:</strong> <%= format_date(choose_better_date(project['end-actual'], project['end-planned'])) %> </p>
+                 <p><strong>Start Date:</strong> <%#= format_date(choose_better_date(project['start-actual'], project['start-planned'])) %></p>
+                 <p><strong>End Date:</strong> <%#= format_date(choose_better_date(project['end-actual'], project['end-planned'])) %> </p>
             </div>
         <![endif]-->
 
@@ -210,18 +210,18 @@ title: Development Tracker
 
             var funding = [ {label: "", text: "", value: 0},
                             {label: "Budget spend to date", text: "<%#= number_to_currency(project['totalProjectSpend'], :unit=>currency_symbol(project['currency']) || "£", :precision => 0) || 0.00 %>", value: <%= (project['totalProjectSpend'] || 0.00) %>},
-                            {label: "Project budget", text: "<%#= number_to_currency(project['totalBudget'], :unit=>currency_symbol(project['currency']) || "£", :precision => 0) || 0.00 %>", value: <%= (project['totalBudget'] || 0.00) %>}]
+                            {label: "Project budget", text: "<%= Money.new(project['total_child_budgets'].to_f.round(0)*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %><%#= number_to_currency(project['total_child_budgets'], :unit=>currency_symbol(project['currency']) || "£", :precision => 0) || 0.00 %>", value: <%= (project['total_child_budgets'] || 0.00) %>}]
             charts.progressBar("#funding-progress", funding, function(d) { return d.value; }, function(d) { return d.label; }, function(d) { return d.text; });
 
-            var time = [ {label: "Start",
-                          text: "<%= format_date(choose_better_date(project['activity_dates']['start_actual'], project['activity_dates']['start_planned'])) %>",
-                          value: <%= choose_better_date(project['activity_dates']['start_actual'], project['activity_dates']['start_planned']) %>},
+            var time = [ {label: "<%=choose_better_date_label(actualStartDate(project['activity_dates']),plannedStartDate(project['activity_dates'])) %> Start",
+                          text: "<%= format_date(choose_better_date(actualStartDate(project['activity_dates']),plannedStartDate(project['activity_dates'])))%>",
+                          value: <%= choose_better_date(actualStartDate(project['activity_dates']), plannedStartDate(project['activity_dates'])) %>},
                          {label: "Progress by time",
                           text: "",
                           value: new Date().getTime()},
-                         {label: "End",
-                          text: "<%= format_date(choose_better_date(project['activity_dates']['end_actual'], project['activity_dates']['end_planned'])) %>",
-                          value: <%= choose_better_date(project['activity_dates']['end_actual'],   project['activity_dates']['end_planned']) %>}];
+                         {label: "<%=choose_better_date_label(actualEndDate(project['activity_dates']),plannedEndDate(project['activity_dates'])) %> End",
+                          text: "<%= format_date(choose_better_date(actualEndDate(project['activity_dates']), plannedEndDate(project['activity_dates']))) %>",
+                          value: <%= choose_better_date(actualEndDate(project['activity_dates']), plannedEndDate(project['activity_dates'])) %>}];
             charts.progressBar("#time-progress", time, function(d) { return d.value; }, function(d) { return d.label; }, function(d) { return d.text; });
 
             var budgets = 0;<%#= ([["Year" ,"Plan", "Spend"]]) + (project_budget_per_fy project['iatiId']) %>;

--- a/views/projects/summary.html.erb
+++ b/views/projects/summary.html.erb
@@ -208,7 +208,7 @@ title: Development Tracker
             charts.donutLegend("#sector-legend", ".legend-color", 14, sectors, function(d){ return d.sector });
 
             var funding = [ {label: "", text: "", value: 0},
-                            {label: "Budget spend to date", text: "<%#= number_to_currency(project['totalProjectSpend'], :unit=>currency_symbol(project['currency']) || "£", :precision => 0) || 0.00 %>", value: <%= (project['totalProjectSpend'] || 0.00) %>},
+                            {label: "Spend to date", text: "<%#= number_to_currency(project['totalProjectSpend'], :unit=>currency_symbol(project['currency']) || "£", :precision => 0) || 0.00 %>", value: <%= (project['totalProjectSpend'] || 0.00) %>},
                             {label: "Project budget", text: "<%= Money.new(project['total_child_budgets'].to_f.round(0)*100, project['default_currency']['code']).format(:no_cents_if_whole => true,:sign_before_symbol => false) %><%#= number_to_currency(project['total_child_budgets'], :unit=>currency_symbol(project['currency']) || "£", :precision => 0) || 0.00 %>", value: <%= (project['total_child_budgets'] || 0.00) %>}]
             charts.progressBar("#funding-progress", funding, function(d) { return d.value; }, function(d) { return d.label; }, function(d) { return d.text; });
 


### PR DESCRIPTION
Fixed dates on the project summary page:
Added new functions to return planned/actual start/end dates in common_helpers class
Added a label showing the date type chosen as part of the slider graphic
Made style changes to show the reporting_org name more clearly on the page
Added logic to determine reporting_org name if the name is not explicit in the data