### PR TITLE
fixed search so that non-DFID projects have budget values

### DIFF
--- a/views/search/search.html.erb
+++ b/views/search/search.html.erb
@@ -109,8 +109,17 @@
                                 </a>
                             <%end%>
                         </h3>
-                        <%unless project['activity_aggregations']['total_child_budget_value'].nil? %>
-                        <span class="budget">Budget: <em> <%= Money.new(project['activity_aggregations']['total_child_budget_value'].to_f*100,"GBP").format(:no_cents_if_whole => true,:sign_before_symbol => false) %></em></span><%end%>
+                        <%
+                        #to handle different budget aggregations for DFID and non-DFID projects
+                        if is_dfid_project(project['iati_identifier']) then
+                            unless project['activity_aggregations']['total_child_budget_value'].nil? %>
+                        <span class="budget">Budget: <em> <%= Money.new(project['activity_aggregations']['total_child_budget_value'].to_f*100,"GBP").format(:no_cents_if_whole => true,:sign_before_symbol => false) %></em></span>
+                        <%end
+                        else
+                            unless project['activity_aggregations']['total_budget_value'].nil? %>
+                        <span class="budget">Budget: <em> <%= Money.new(project['activity_aggregations']['total_budget_value'].to_f*100,"GBP").format(:no_cents_if_whole => true,:sign_before_symbol => false) %></em></span>
+                            <%end
+                        end%>
                         <%unless project['activity_status']['name'].nil? %>
                         <span>Status: <em><%=project['activity_status']['name'].to_s %></em></span>
                         <%end%>


### PR DESCRIPTION
Non-DFID projects in the search result pages were returning zero budgets. Fixed by updating the search page template to pull back total_budget_value for those projects.