### PR TITLE
Added the location filters for the sector and removed GB-1 filter fro…

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -443,7 +443,9 @@ get '/sector/:high_level_sector_code/projects/?' do
 	 		highLevelSectorList: getSectorProjects['highLevelSectorList'],
 	 		budgetHigherBound: getSectorProjects['project_budget_higher_bound'],
 	 		actualStartDate: getSectorProjects['actualStartDate'],
- 			plannedEndDate: getSectorProjects['plannedEndDate']
+ 			plannedEndDate: getSectorProjects['plannedEndDate'],
+ 			locationCountryFilters: getSectorProjects['LocationCountries'],
+ 			locationRegionFilters: getSectorProjects['LocationRegions']
  		}	
 end
 
@@ -482,7 +484,9 @@ get '/sector/:high_level_sector_code/categories/:category_code/projects/?' do
 	 		highLevelSectorList: getSectorProjects['highLevelSectorList'],
 	 		budgetHigherBound: getSectorProjects['project_budget_higher_bound'],
 	 		actualStartDate: getSectorProjects['actualStartDate'],
- 			plannedEndDate: getSectorProjects['plannedEndDate']
+ 			plannedEndDate: getSectorProjects['plannedEndDate'],
+ 			locationCountryFilters: getSectorProjects['LocationCountries'],
+ 			locationRegionFilters: getSectorProjects['LocationRegions']
  		}	
 end
 
@@ -510,7 +514,9 @@ get '/sector/:high_level_sector_code/categories/:category_code/projects/:sector_
 	 		highLevelSectorList: getSectorProjects['highLevelSectorList'],
 	 		budgetHigherBound: getSectorProjects['project_budget_higher_bound'],
 	 		actualStartDate: getSectorProjects['actualStartDate'],
- 			plannedEndDate: getSectorProjects['plannedEndDate']
+ 			plannedEndDate: getSectorProjects['plannedEndDate'],
+ 			locationCountryFilters: getSectorProjects['LocationCountries'],
+ 			locationRegionFilters: getSectorProjects['LocationRegions']
  		}		
 end
 

--- a/helpers/sector_helpers.rb
+++ b/helpers/sector_helpers.rb
@@ -155,6 +155,9 @@ module SectorHelpers
 		results = {}
 		sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-1&related_activity_sector=#{n}"
 		results['highLevelSectorList'] = high_level_sector_list_filter(sectorValuesJSON)
+		#results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities?hierarchy=1&format=json&reporting_organisation=GB-1&page_size=10&fields=description,activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations&activity_status=1,2,3,4,5&ordering=-total_plus_child_budget_value&related_activity_sector=#{n}")
+		results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations?hierarchy=1&format=json&reporting_organisation=GB-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}")
+		results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations?hierarchy=1&format=json&reporting_organisation=GB-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}")
 		results['project_budget_higher_bound'] = 0
 		results['actualStartDate'] = '0000-00-00T00:00:00' 
 		results['plannedEndDate'] = '0000-00-00T00:00:00'

--- a/public/javascripts/searchPageFilters.js
+++ b/public/javascripts/searchPageFilters.js
@@ -15,10 +15,10 @@ $(document).ready(function() {
             oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&reporting_organisation=GB-1&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val()+'&related_activity_recipient_country='+window.CountryCode;
             break;
         case 'F':
-            oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&reporting_organisation=GB-1&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&q='+window.searchQuery+'&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val();
+            oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&q='+window.searchQuery+'&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val();
             break;
         case 'S':
-            oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&reporting_organisation=GB-1&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val()+'&related_activity_sector='+window.SectorCode;
+            oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&reporting_organisation=GB-1&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val()+'&related_activity_sector='+window.SectorCode + '&recipient_country=' + $('#locationCountryFilterStates').val() + '&recipient_region=' + $('#locationRegionFilterStates').val();
             break;
         case 'R':
             oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&reporting_organisation=GB-1&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val()+'&related_activity_recipient_region='+window.RegionCode;
@@ -30,10 +30,10 @@ $(document).ready(function() {
                 oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&reporting_organisation=GB-1&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val()+'&related_activity_recipient_country='+window.CountryCode;
                 break;
             case 'F':
-                oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&reporting_organisation=GB-1&format=json&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&q='+window.searchQuery+'&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val();
+                oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&q='+window.searchQuery+'&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val();
                 break;
             case 'S':
-                oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&reporting_organisation=GB-1&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val()+'&related_activity_sector='+window.SectorCode;
+                oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&reporting_organisation=GB-1&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val()+'&related_activity_sector='+window.SectorCode + '&recipient_country=' + $('#locationCountryFilterStates').val() + '&recipient_region=' + $('#locationRegionFilterStates').val();
                 break;
             case 'R':
                 oipaLink = window.oipaApiUrl + 'activities?hierarchy=1&page_size=10&format=json&reporting_organisation=GB-1&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_aggregations,description&activity_status='+$('#activity_status_states').val()+'&ordering='+$('#sort_results_type').val()+'&total_plus_child_budget_value_gte='+$('#budget_lower_bound').val()+'&total_plus_child_budget_value_lte='+$('#budget_higher_bound').val()+'&actual_start_date_gte='+$('#date_lower_bound').val()+'&planned_end_date_lte='+$('#date_higher_bound').val()+'&sector='+$('#selected_sectors').val()+'&related_activity_recipient_region='+window.RegionCode;
@@ -104,6 +104,22 @@ $(document).ready(function() {
     $('.sector').click(function(){
         var tmpSectorList = $('.sector:checked').map(function(){return $(this).val()}).get().join();
         $('#selected_sectors').val(tmpSectorList);
+        refreshOipaLink(window.searchType);
+        generateProjectListAjax(oipaLink);
+    });
+
+    //The following updates the result based on selected location country filter
+    $('.location_country').click(function(){
+        var tmpCountryList = $('.location_country:checked').map(function(){return $(this).val()}).get().join();
+        $('#locationCountryFilterStates').val(tmpCountryList);
+        refreshOipaLink(window.searchType);
+        generateProjectListAjax(oipaLink);
+    });
+
+    //The following updates the result based on selected location region filter
+    $('.location_region').click(function(){
+        var tmpRegionList = $('.location_region:checked').map(function(){return $(this).val()}).get().join();
+        $('#locationRegionFilterStates').val(tmpRegionList);
         refreshOipaLink(window.searchType);
         generateProjectListAjax(oipaLink);
     });

--- a/views/location/country/index.html.erb
+++ b/views/location/country/index.html.erb
@@ -16,7 +16,7 @@
                 <script type="text/javascript">
                     var countriesData = <%= dfid_country_map_data %>;
                 </script>  
-                <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
+<!--                <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script> -->
                 <script src="/javascripts/leaflet/leaflet.js" type="text/javascript"></script>
                 <script src="/javascripts/leaflet/leaflet-googlemaps.js"></script>
                 <script src="/javascripts/leaflet/world.js" type="text/javascript"></script>

--- a/views/partials/_project_list.html.erb
+++ b/views/partials/_project_list.html.erb
@@ -88,21 +88,43 @@
                     </ul>
                     <input type="hidden" id="activity_status_states" value="1,2,3,4,5"  />
                 </div>
-                <div name="locations" style="display: none">
-                    <h3>Locations</h3>
-                    <div style="margin-left:20px;" name="countries">
-                        <div class="proj-filter-exp-collapse-sign">+</div>
-                        <span class="proj-filter-exp-collapse-text" style="cursor:pointer">
-                            <h4>Countries</h4>
-                        </span>
+                <% if defined? sectorData %>
+                    <div name="locations" style="">
+                        <h3>Locations</h3>
+                        <div style="margin-left:20px;" name="countries">
+                            <div class="proj-filter-exp-collapse-sign">+</div>
+                            <span class="proj-filter-exp-collapse-text" style="cursor:pointer">
+                                <h4>Countries</h4>
+                            </span>
+                            <ul style="display: none">
+                                <% locationCountryFilters['results'].each do |countryFilters| %>
+                                <li>
+                                    <label for="location_country_<%= countryFilters['recipient_country']['code'] %>" title=" <%= countryFilters['recipient_country']['name'] %>">
+                                    <input id="location_country_<%= countryFilters['recipient_country']['code'] %>" type="checkbox" value="<%= countryFilters['recipient_country']['code'] %>" class="location_country" name="locationCountry"><%= countryFilters['recipient_country']['name'] %>
+                                    </label>
+                                </li>
+                                <% end %>
+                            </ul>
+                            <input type="hidden" id="locationCountryFilterStates" value=""  />
+                        </div>
+                        <div style="margin-left:20px;" name="regions">
+                            <div class="proj-filter-exp-collapse-sign">+</div>
+                            <span class="proj-filter-exp-collapse-text" style="cursor:pointer">
+                                <h4>Regions</h4>
+                            </span>
+                            <ul style="display: none">
+                                <% locationRegionFilters['results'].each do |regionFilters| %>
+                                <li>
+                                    <label for="location_region_<%= regionFilters['recipient_region']['code'] %>" title=" <%= regionFilters['recipient_region']['name'] %>">
+                                    <input id="location_region_<%= regionFilters['recipient_region']['code'] %>" type="checkbox" value="<%= regionFilters['recipient_region']['code'] %>" class="location_region" name="locationRegion"><%= regionFilters['recipient_region']['name'] %>
+                                    </label>
+                                </li>
+                                <% end %>
+                            </ul>
+                            <input type="hidden" id="locationRegionFilterStates" value=""  />
+                        </div>
                     </div>
-                    <div style="margin-left:20px;" name="regions">
-                        <div class="proj-filter-exp-collapse-sign">+</div>
-                        <span class="proj-filter-exp-collapse-text" style="cursor:pointer">
-                            <h4>Regions</h4>
-                        </span>
-                    </div>
-                </div>
+                <%end%>
                 <div name="sectors">
                     <div class="proj-filter-exp-collapse-sign">+</div>
                     <span class="proj-filter-exp-collapse-text" style="cursor:pointer">

--- a/views/projects/summary.html.erb
+++ b/views/projects/summary.html.erb
@@ -117,7 +117,7 @@
        
         <script src="/javascripts/regionBounds.js" type="text/javascript"></script>
         <script src="/javascripts/leaflet/countryBounds.js" type="text/javascript"></script>
-        <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
+<!--        <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script> -->
         <link rel="stylesheet" type="text/css" href="/javascripts/leaflet/leaflet.css">
         <link rel="stylesheet" type="text/css" href="/javascripts/leaflet/MarkerCluster.css">
         <link rel="stylesheet" type="text/css" href="/javascripts/leaflet/MarkerCluster.Default.css">

--- a/views/regions/region.html.erb
+++ b/views/regions/region.html.erb
@@ -240,7 +240,7 @@
     var mapType = "region";
     var locations = "";<%#= locations.to_json%>
 </script>
-<script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
+<!--<script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script> -->
 <script src="/javascripts/regionBounds.js" type="text/javascript"></script>
 <script src="/javascripts/leaflet/leaflet.js"></script>
 <script src="/javascripts/leaflet/leaflet-googlemaps.js"></script>

--- a/views/sector/projects.html.erb
+++ b/views/sector/projects.html.erb
@@ -24,4 +24,4 @@ title: Development Tracker
 </div>
 
 <%#= partial "partials/_project_list", :locals => { :projects => projects.to_a } %>
-<%= erb :'partials/_project_list', :locals => { :projects => projects, :sectorData => sectorData, :project_count => total_projects, :countryAllProjectFilters => countryAllProjectFilters, :highLevelSectorList => highLevelSectorList, :oipa_api_url => oipa_api_url, :total_projects => total_projects, :budgetHigherBound => budgetHigherBound, :actualStartDate => actualStartDate, :plannedEndDate => plannedEndDate } %>
+<%= erb :'partials/_project_list', :locals => { :projects => projects, :sectorData => sectorData, :project_count => total_projects, :countryAllProjectFilters => countryAllProjectFilters, :highLevelSectorList => highLevelSectorList, :oipa_api_url => oipa_api_url, :total_projects => total_projects, :budgetHigherBound => budgetHigherBound, :actualStartDate => actualStartDate, :plannedEndDate => plannedEndDate, :locationCountryFilters => locationCountryFilters, :locationRegionFilters => locationRegionFilters } %>


### PR DESCRIPTION
1. **devtracker.rb** - Added the location filter data for different sector results pages.
2. **helpers/search_helper.rb** - Removed the 'reporting_organisation=GB-1' from the api calls to make sure non DFID projects show up as well.
3. **helpers/sector_helpers.rb** - Returned two new information ie. country and region data for the location filter.
4. **public/javascripts/searchPageFilters.js** - Updated the code to remove the 'reporting_organisation=GB-1' filter from the free text search query and also added two new jquery methods to handle the location filters.
5. **views/partials/_project_list.html.erb** - Added the location filter data inside the template.
6. **views/sector/projects.html.erb** - Passed two new parameters to enable the location filter.
7. **views/regions/region.html.erb** - Commented out the google maps api.
8. **views/location/country/index.html.erb** - Commented out the google maps api.
9. **views/projects/summary.html.erb** - Commented out the google maps api.