### PR TITLE
Allowed lower case characters in the sanitizer for project IDs

### DIFF
--- a/helpers/input_sanitizer.rb
+++ b/helpers/input_sanitizer.rb
@@ -12,7 +12,7 @@ module InputSanitizer
 			return string.gsub(/[^0-9+\s]/,'')
 		when "p"
 			#Handles the country codes, region codes and project IDs
-			return string.gsub(/[^A-Z0-9\s\-]/,'')
+			return string.gsub(/[^a-zA-Z0-9\-\s]/,'')
 		else
 			#anything other than those specified will act similar to the case 'a' by default
 			return string.gsub(/[^a-zA-Z0-9\s_\/\-]/,'')


### PR DESCRIPTION
Sanitizer was replacing lower case characters in project IDs which meant that some project IDs were returning a 404