### PR TITLE
Update departmental search terms

### DIFF
--- a/helpers/input_sanitizer.rb
+++ b/helpers/input_sanitizer.rb
@@ -13,6 +13,9 @@ module InputSanitizer
 		when "p"
 			#Handles the country codes, region codes and project IDs
 			return string.gsub(/[^a-zA-Z0-9\-\s_]/,'')
+		when "id"
+			#Removes slashes from project IDs
+			return string.gsub(/\//,'-')
 		else
 			#anything other than those specified will act similar to the case 'a' by default
 			return string.gsub(/[^a-zA-Z0-9\s_\/\-]/,'')

--- a/views/department/department.html.erb
+++ b/views/department/department.html.erb
@@ -37,16 +37,16 @@ title: Development Tracker
     
     <div class="four columns">
          <ol>
-           <li><a href="/search?query=Department+of+Energy+and+Climate+Change+GB-4">Department of Energy and Climate Change</a></li>
+           <li><a href="/search?query=GB-4">Department of Energy and Climate Change</a></li>
            <li><a href="/sector">Department for International Development (by Sector)</a></li>   
-           <li><a href="/search?query=UK+-+Home+Office+GB-6">Home Office</a></li>   
+           <li><a href="/search?query=GB-6">Home Office</a></li>   
         </ol>        
     </div>
 
     <div class="four columns">
           <ol>
-           <li><a href="/search?query=Department+for+Environment+Food+and+Rural+Affairs">Department for Environment Food and Rural Affairs</a></li>         
-           <li><a class="url-margin" href="/search?query=UK+Department+of+Health+GB-10+WHO">Department of Health </a></li>
+           <li><a href="/search?query=GB-7">Department for Environment Food and Rural Affairs</a></li>         
+           <li><a class="url-margin" href="/search?query=GB-10+WHO">Department of Health </a></li>
            <li><a href="/search?query=GB-COH-RC000346">Medical Research Council</a></li>                     
          </ol>
    </div>
@@ -54,8 +54,8 @@ title: Development Tracker
     <div class="four columns">       
         <ol>
           <li><a href="/location/country/">Department for International Development (by Location)</a></li>
-          <li><a class="url-margin" href="/search?query=Department+for+Work+and+Pensions">Department for Work and Pensions</a></li>
-          <li><a href="/search?query=UK+-+Ministry+of+Defence">Ministry of Defence</a></li>             
+          <li><a class="url-margin" href="/search?query=GB-9">Department for Work and Pensions</a></li>
+          <li><a href="/search?query=GB-GOV-8">Ministry of Defence</a></li>             
         </ol>        
     </div>
 

--- a/views/search/search.html.erb
+++ b/views/search/search.html.erb
@@ -99,7 +99,7 @@
                     <div class="search-result">
                         <h3>    
                             <%unless project['iati_identifier'].nil? %>
-                                <a href="/projects/<%= project['iati_identifier'] %>">
+                                <a href="/projects/<%= sanitize_input(project['iati_identifier'],"id") %>">
                                 <%unless project['title']['narratives'].nil? %>
                                     <%unless project['title']['narratives'][0]['text'].nil? %>
                                         <%=project['title']['narratives'][0]['text']%>


### PR DESCRIPTION
1. Updated department page with search terms - use reporting_organisation identifier only
2. Sanitized URLs on project search page to replace / with - to make the URLs work (for example for MRC)