### PR TITLE
Added Research pages fetching R4D docs from the R4D API

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -304,6 +304,14 @@ get '/projects/:proj_id/?' do |n|
 
 	# get the funded projects Count from the API
 	fundedProjectsCount = get_funded_project_count(n)
+
+	# get the R4D docs count from the R4D API
+	begin
+		r4dDocs = r4DApiDocFetch(n) || ''
+		r4dDocsCount = r4dDocs.count
+	rescue
+		r4dDocsCount = 0
+	end
 	
 	erb :'projects/summary', 
 		:layout => :'layouts/layout',
@@ -313,7 +321,8 @@ get '/projects/:proj_id/?' do |n|
  			fundedProjectsCount: fundedProjectsCount,
  			fundingProjectsCount: fundingProjectsCount,
  			#projectBudget: projectBudget,
- 			projectSectorGraphData: projectSectorGraphData
+ 			projectSectorGraphData: projectSectorGraphData,
+ 			r4dDocsCount: r4dDocsCount
  		}
 end
 
@@ -331,6 +340,14 @@ get '/projects/:proj_id/documents/?' do |n|
 
 	# get the funded projects Count from the API
 	fundedProjectsCount = get_funded_project_count(n)
+
+	# get the R4D docs count from the R4D API
+	begin
+		r4dDocs = r4DApiDocFetch(n) || ''
+		r4dDocsCount = r4dDocs.count
+	rescue
+		r4dDocsCount = 0
+	end
   	
 	erb :'projects/documents', 
 		:layout => :'layouts/layout',
@@ -338,7 +355,8 @@ get '/projects/:proj_id/documents/?' do |n|
  			project: project,
  			countryOrRegion: countryOrRegion,
  			fundedProjectsCount: fundedProjectsCount,
- 			fundingProjectsCount: fundingProjectsCount 
+ 			fundingProjectsCount: fundingProjectsCount,
+ 			r4dDocsCount: r4dDocsCount
  		}
 end
 
@@ -362,6 +380,14 @@ get '/projects/:proj_id/transactions/?' do |n|
 
 	# get the funded projects Count from the API
 	fundedProjectsCount = get_funded_project_count(n)
+
+	# get the R4D docs count from the R4D API
+	begin
+		r4dDocs = r4DApiDocFetch(n) || ''
+		r4dDocsCount = r4dDocs.count
+	rescue
+		r4dDocsCount = 0
+	end
 	
 	erb :'projects/transactions', 
 		:layout => :'layouts/layout',
@@ -371,7 +397,8 @@ get '/projects/:proj_id/transactions/?' do |n|
  			transactions: transactions,
  			projectYearWiseBudgets: projectYearWiseBudgets, 			
  			fundedProjectsCount: fundedProjectsCount,
- 			fundingProjectsCount: fundingProjectsCount 
+ 			fundingProjectsCount: fundingProjectsCount,
+ 			r4dDocsCount: r4dDocsCount 
  		}
 end
 
@@ -391,6 +418,14 @@ get '/projects/:proj_id/partners/?' do |n|
 	# get the funded projects from the API
 	fundedProjectsData = get_funded_project_details(n)
 
+	# get the R4D docs count from the R4D API
+	begin
+		r4dDocs = r4DApiDocFetch(n) || ''
+		r4dDocsCount = r4dDocs.count
+	rescue
+		r4dDocsCount = 0
+	end
+
 	erb :'projects/partners', 
 		:layout => :'layouts/layout',
 		:locals => {
@@ -399,7 +434,46 @@ get '/projects/:proj_id/partners/?' do |n|
  			fundedProjects: fundedProjectsData['results'],
  			fundedProjectsCount: fundedProjectsData['count'],
  			fundingProjects: fundingProjects,
- 			fundingProjectsCount: fundingProjectsData['count']
+ 			fundingProjectsCount: fundingProjectsData['count'],
+ 			r4dDocsCount: r4dDocsCount 
+ 		}
+end
+
+#Project research page
+get '/projects/:proj_id/research/?' do |n|
+	n = sanitize_input(n,"p")
+	# get the project data from the API
+  	project = get_h1_project_details(n)
+
+  	#get the country/region data from the API
+  	countryOrRegion = get_country_or_region(n)
+
+  	#get total project budget and spend Data
+  	#projectBudget = get_project_budget(n)
+
+  	#get project sectorwise graph  data
+  	projectSectorGraphData = get_project_sector_graph_data(n)
+  	
+	# get the funding projects Count from the API
+  	fundingProjectsCount = get_funding_project_count(n)
+
+	# get the funded projects Count from the API
+	fundedProjectsCount = get_funded_project_count(n)
+
+	# get the R4D docs count from the R4D API
+	r4dDocs = r4DApiDocFetch(n) || ''
+	r4dDocsCount = r4dDocs.count
+	
+	erb :'projects/research', 
+		:layout => :'layouts/layout',
+		 :locals => {
+ 			project: project,
+ 			countryOrRegion: countryOrRegion,	 					 			
+ 			fundedProjectsCount: fundedProjectsCount,
+ 			fundingProjectsCount: fundingProjectsCount,
+ 			projectSectorGraphData: projectSectorGraphData,
+ 			r4dDocsCount: r4dDocsCount,
+ 			r4dDocs: r4dDocs
  		}
 end
 

--- a/views/partials/_projects-header.html.erb
+++ b/views/partials/_projects-header.html.erb
@@ -37,11 +37,12 @@
                             <li <%= active=="summary" ? "class='active'" : ""%>><a href="/projects/<%=project['iati_identifier']%>">Summary</a></li>
                             <li <%= active=="documents" ? "class='active'" : ""%>><a href="/projects/<%=project['iati_identifier']%>/documents">Documents (<%= project['document_links'].count %>)</a></li>
                             <li <%= active=="transactions" ? "class='active'" : ""%>><a href="/projects/<%=project['iati_identifier']%>/transactions">Transactions</a></li>
-                            <% if fundedProjectsCount > 0 || fundingProjectsCount > 0 then %>
+                            <% if r4dDocsCount > 0 then %>
+                                <li <%= active=="research" ? "class='active'" : ""%>><a href="/projects/<%=project['iati_identifier']%>/research">Research (<%= r4dDocsCount %>)</a></li>
+                            <% end %>
+                           <% if fundedProjectsCount > 0 || fundingProjectsCount > 0 then %>
                                 <li <%= active=="partners" ? "class='active'" : ""%>><a href="/projects/<%=project['iati_identifier']%>/partners">Partners</a></li>
                             <% end %>
-
-                            <!-- TODO: bring back in r4dDocs element -->
                         </ul>
                     </nav>
                 </div>          

--- a/views/projects/documents.html.erb
+++ b/views/projects/documents.html.erb
@@ -1,4 +1,4 @@
-<%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :active => "documents"} %>
+<%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :r4dDocsCount => r4dDocsCount, :active => "documents"} %>
 
 <div class="row">
     <div class="twelve columns summary">

--- a/views/projects/partners.html.erb
+++ b/views/projects/partners.html.erb
@@ -1,6 +1,6 @@
 <!-- title: Development Tracker -->
 
-<%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :active => "partners"} %>
+<%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :r4dDocsCount => r4dDocsCount, :active => "partners"} %>
 
   <% if fundingProjectsCount > 0 then %>
       <div class="row">

--- a/views/projects/research.html.erb
+++ b/views/projects/research.html.erb
@@ -1,14 +1,8 @@
----
-published: "true"
-title: Development Tracker
-
----
-
-<%= partial "partials/projects-header", :locals => { :project => project, :active => "r4dDocs", :has_funded_projects => has_funded_projects} %>
+<%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :r4dDocsCount => r4dDocsCount, :active => "research"} %>
 
 <div class="row">
     <div class="twelve columns summary">    
-        <% r4dDocs = r4DApiDocFetch(project['iatiId']) || '' %>
+        <% #r4dDocs = r4DApiDocFetch(project['iatiId']) || '' %>
         <%if !r4dDocs.nil? && r4dDocs.length > 0 %>
           <p>This project has supported the following research projects and/or publications</p>
           <% r4dDocs.each do |s| %>

--- a/views/projects/summary.html.erb
+++ b/views/projects/summary.html.erb
@@ -1,5 +1,5 @@
 
-<%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :active => "summary"} %>
+<%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :r4dDocsCount => r4dDocsCount, :active => "summary"} %>
 
 <div class="row">
     <div class="twelve columns">

--- a/views/projects/transactions.html.erb
+++ b/views/projects/transactions.html.erb
@@ -2,7 +2,7 @@
 title: Development Tracker
 --- -->
 
-<%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :active => "transactions"} %>
+<%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :r4dDocsCount => r4dDocsCount, :active => "transactions"} %>
 
 <%# ------------------------------------------------------------------------ %>
 <%#                       B U D G E T S   T A B L E                          %>


### PR DESCRIPTION
1. Updated devtracker.rb to add in a call for the R4D API. Wrapped in begin..rescue to cope with the possibility of the R4D API not being available
2. Updated the following template files to add in the Research tab:
    summary.html.erb
    documents.html.erb
    transactions.html.erb
    partners.html.erb
3. Renamed r4dDocs.html.erb page to research.html.erb
4. Updated the research.html.erb page to handle the r4dDocs object

Tested the unavailability of the r4D API by altering the URI.