### PR TITLE
Removed summary button from the all regions / all global projects page.

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -179,7 +179,7 @@ get '/global' do
 	region[:name] = "All"
 	getRegionProjects = get_region_projects(region[:code])
   	settings.devtracker_page_title = 'Global All Projects Page'
-	erb :'regions/projects', 
+	erb :'regions/projects-home', 
 		:layout => :'layouts/layout',
 		:locals => {
 			oipa_api_url: settings.oipa_api_url,
@@ -238,7 +238,7 @@ get '/regions' do
 	region[:name] = "All"
 	getRegionProjects = get_region_projects(region[:code])
   	settings.devtracker_page_title = 'Region '+region[:name]+' Projects Page'
-	erb :'regions/projects', 
+	erb :'regions/projects-home', 
 		:layout => :'layouts/layout',
 		:locals => {
 			oipa_api_url: settings.oipa_api_url,

--- a/views/partials/_regions-summary-tabs.html.erb
+++ b/views/partials/_regions-summary-tabs.html.erb
@@ -1,0 +1,29 @@
+<div class="row">
+    <div class="twelve columns">
+        <div class="tab-bar-container">
+            <div class="row">
+
+                <div class="projects-nav six columns">
+                    <nav>
+                        <ul class="tab-bar">
+                            <li <%= active=="projects" ? "class='active'" : ""%>><a href="/regions/<%= region[:code] %>/projects">All Projects (<%=project_count%>)</a></li>
+                        </ul>
+                    </nav>
+                </div>  
+
+                 <div class="button-row six columns">
+                    <% regionSubscription = false
+                    if project_count > 0  && regionSubscription%>
+                    <span>
+                        <a href="https://public.govdelivery.com/accounts/UKDFID/subscriber/new?topic_id=UKDFID_<%= format_query_string region['code'] %>" title="Subscribe to receive updates on <%= region['name'] %> by email" class="button inform">&#9993; Subscribe</a>
+                    </span>
+                    <% end %>
+                     <span>
+                        <a href="/fraud?region=<%= format_query_string region[:name] %>" class="button serious" title="Report fraud">Report Fraud</a>
+                    </span>
+                </div>  
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/views/regions/projects-home.erb
+++ b/views/regions/projects-home.erb
@@ -1,0 +1,25 @@
+
+<div id="page-title" class="row">
+    <div class="twelve columns">
+        <img src="/images/ukaid_logo.png" alt="UK aid from the British people">
+        <div>
+            <div class="breadcrumb">
+                <ul>
+                    <li><a href="/">Home</a></li>
+                    <% if region[:type] == "Regional" then %>
+                    <li><a href="/location/regional">Aid by Location</a></li>
+                    <% else %>
+                    <li><a href="/location/global">Aid by Location</a></li>
+                    <% end %>
+                    <li><%= region[:name] %></li>
+                </ul>
+            </div>
+            <h1>
+                <%= region[:name] + " Region"%>
+            </h1>
+        </div>
+    </div>
+</div>
+
+<%= erb :'partials/_regions-summary-tabs', :locals => { :active => "projects", :region => region, :project_count => total_projects} %>
+<%= erb :'partials/_project_list', :locals => { :projects => projects, :region => region, :project_count => total_projects, :countryAllProjectFilters => countryAllProjectFilters, :highLevelSectorList => highLevelSectorList, :oipa_api_url => oipa_api_url, :total_projects => total_projects, :budgetHigherBound => budgetHigherBound, :actualStartDate => actualStartDate, :plannedEndDate => plannedEndDate } %>


### PR DESCRIPTION
1. **devtracker.rb** - Updated the template calls so that all regions and all global page has their own header template instead of using region specific template.
2. **views/partials/_regions-summary-tabs.html.erb** - This is the partial template for all regions / all global projects page without the summary link.
3. **views/regions/projects-home.erb** - New template that calls the above new partial template for the all regions / all global projects page.