### PR TITLE
Updated codes to show only active project data by default

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -147,7 +147,8 @@ get '/countries/:country_code/projects/?' do |n|
 	 		actualStartDate: projectData['actualStartDate'],
 	 		plannedEndDate: projectData['plannedEndDate'],
 	 		documentTypes: projectData['document_types'],
-	 		implementingOrgTypes: projectData['implementingOrg_types']
+	 		implementingOrgTypes: projectData['implementingOrg_types'],
+	 		projectCount: projectData['projects']['count']
 	 	}
 		 			
 end
@@ -197,7 +198,8 @@ get '/global' do
 	 		actualStartDate: getRegionProjects['actualStartDate'],
  			plannedEndDate: getRegionProjects['plannedEndDate'],
  			documentTypes: getRegionProjects['document_types'],
- 			implementingOrgTypes: getRegionProjects['implementingOrg_types']
+ 			implementingOrgTypes: getRegionProjects['implementingOrg_types'],
+ 			projectCount: getRegionProjects['projects']['count']
 		}
 end
 
@@ -231,7 +233,8 @@ get '/global/:global_code/projects/?' do |n|
 	 		actualStartDate: getRegionProjects['actualStartDate'],
  			plannedEndDate: getRegionProjects['plannedEndDate'],
  			documentTypes: getRegionProjects['document_types'],
- 			implementingOrgTypes: getRegionProjects['implementingOrg_types']
+ 			implementingOrgTypes: getRegionProjects['implementingOrg_types'],
+ 			projectCount: getRegionProjects['projects']['count']
 		}	 			
 end
 
@@ -301,7 +304,8 @@ get '/regions/:region_code/projects/?' do |n|
 	 		actualStartDate: getRegionProjects['actualStartDate'],
  			plannedEndDate: getRegionProjects['plannedEndDate'],
  			documentTypes: getRegionProjects['document_types'],
- 			implementingOrgTypes: getRegionProjects['implementingOrg_types']
+ 			implementingOrgTypes: getRegionProjects['implementingOrg_types'],
+ 			projectCount: getRegionProjects['projects']['count']
 		}	 			
 end
 

--- a/helpers/country_helpers.rb
+++ b/helpers/country_helpers.rb
@@ -105,7 +105,7 @@ module CountryHelpers
       currentTotalCountryBudget= get_current_total_budget(RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&reporting_organisation=GB-GOV-1&budget_period_start=#{firstDayOfFinYear}&budget_period_end=#{lastDayOfFinYear}&group_by=recipient_country&aggregations=budget&recipient_country=#{countryCode}")
       currentTotalDFIDBudget = get_current_dfid_total_budget(RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&reporting_organisation=GB-GOV-1&budget_period_start=#{firstDayOfFinYear}&budget_period_end=#{lastDayOfFinYear}&group_by=reporting_organisation&aggregations=budget")
 
-      totalProjectsDetails = get_total_project(RestClient.get settings.oipa_api_url + "activities/?reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&format=json&fields=activity_status&page_size=250")
+      totalProjectsDetails = get_total_project(RestClient.get settings.oipa_api_url + "activities/?reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&format=json&fields=activity_status&page_size=250&activity_status=2")
       totalActiveProjects = totalProjectsDetails['results'].select {|status| status['activity_status']['code'] =="2" }.length
 
       if countryOperationalBudget.length > 0 then
@@ -291,9 +291,12 @@ module CountryHelpers
     allProjectsData['countryAllProjectFilters'] = get_static_filter_list()
     allProjectsData['country'] = get_country_code_name(countryCode)
     allProjectsData['results'] = get_country_results(countryCode)
-    oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&related_activity_recipient_country=#{countryCode}"
+    #oipa_project_list_count = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&related_activity_recipient_country=#{countryCode}"
+    #allProjectsData['projectsCount']= JSON.parse(oipa_project_list_count)
+
+    oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_recipient_country=#{countryCode}"
     allProjectsData['projects']= JSON.parse(oipa_project_list)
-    sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_recipient_country=#{countryCode}"
+    sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_recipient_country=#{countryCode}&activity_status=2"
     allProjectsData['highLevelSectorList'] = high_level_sector_list_filter(sectorValuesJSON)
     #projects = projects_list['results']
     allProjectsData['project_budget_higher_bound'] = 0
@@ -302,7 +305,7 @@ module CountryHelpers
     unless allProjectsData['projects']['results'][0].nil?
       allProjectsData['project_budget_higher_bound'] = allProjectsData['projects']['results'][0]['aggregations']['activity_children']['budget_value']
     end
-    allProjectsData['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&ordering=actual_start_date&start_date_gte=1900-01-02"
+    allProjectsData['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
     allProjectsData['actualStartDate'] = JSON.parse(allProjectsData['actualStartDate'])
     tempStartDate = allProjectsData['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '2'}.first
     if (tempStartDate.nil?)
@@ -314,20 +317,20 @@ module CountryHelpers
     #unless allProjectsData['actualStartDate']['results'][0].nil? 
     #  allProjectsData['actualStartDate'] = allProjectsData['actualStartDate']['results'][0]['activity_dates'][1]['iso_date']
     #end
-    allProjectsData['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&ordering=-planned_end_date&end_date_isnull=False"
+    allProjectsData['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
     allProjectsData['plannedEndDate'] = JSON.parse(allProjectsData['plannedEndDate'])
     allProjectsData['plannedEndDate'] = allProjectsData['plannedEndDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '3'}.first
     allProjectsData['plannedEndDate'] = allProjectsData['plannedEndDate']['iso_date']
     #unless allProjectsData['plannedEndDate']['results'][0].nil?
     #  allProjectsData['plannedEndDate'] = allProjectsData['plannedEndDate']['results'][0]['activity_dates'][2]['iso_date']
     #end
-    oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_recipient_country=#{countryCode}"
+    oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_recipient_country=#{countryCode}&activity_status=2"
     document_type_list = JSON.parse(oipa_document_type_list)
     allProjectsData['document_types'] = document_type_list['results']
 
     #Implementing org type filters
     participatingOrgInfo = JSON.parse(File.read('data/participatingOrgList.json'))
-    oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_recipient_country=#{countryCode}&hierarchy=1"
+    oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_recipient_country=#{countryCode}&hierarchy=1&activity_status=2"
     implementingOrg_type_list = JSON.parse(oipa_implementingOrg_type_list)
     allProjectsData['implementingOrg_types'] = implementingOrg_type_list['results']
     allProjectsData['implementingOrg_types'].each do |implementingOrgs|
@@ -349,7 +352,7 @@ module CountryHelpers
 
   def get_country_all_projects_data_para(countryCode)
     allProjectsData = {}
-    apiLinks = [{"title"=>"oipa_project_list", "link"=>"activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&related_activity_recipient_country=#{countryCode}"},{"title"=>"sectorValuesJSON", "link"=>"activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_recipient_country=#{countryCode}"},{"title"=>"actualStartDate", "link"=>"activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&ordering=actual_start_date"},{"title"=>"plannedEndDate", "link"=>"activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&ordering=-planned_end_date"}]
+    apiLinks = [{"title"=>"oipa_project_list", "link"=>"activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_recipient_country=#{countryCode}"},{"title"=>"sectorValuesJSON", "link"=>"activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_recipient_country=#{countryCode}"},{"title"=>"actualStartDate", "link"=>"activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&ordering=actual_start_date"},{"title"=>"plannedEndDate", "link"=>"activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_recipient_country=#{countryCode}&ordering=-planned_end_date"}]
     returnedAPIData = ""
     EM.synchrony do
       concurrency = 4

--- a/helpers/search_helper.rb
+++ b/helpers/search_helper.rb
@@ -74,7 +74,7 @@ Returns a Hash 'searchedData' with the following keys:
 			searchedData['dfidRegionBudgets'][results["code"]][1] = results["name"] # Storing the region name
 		end
 		# This json call is pulling the total budget list based on the 'recipient_countries' string previously created
-		oipa_total_project_budget = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&reporting_organisation=GB-GOV-1&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}&group_by=recipient_country&aggregations=budget&recipient_country="+recipient_countries
+		oipa_total_project_budget = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&reporting_organisation=GB-GOV-1&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}&activity_status=2&group_by=recipient_country&aggregations=budget&recipient_country="+recipient_countries
 		countries_project_budget = JSON.parse_nil(oipa_total_project_budget) # Parsed the returned json data and storing it as a hash
 		# This check is necessary to make sure if there really exists a DFID country list matching with the search query else won't try to 
 		# parse and store budget data for the 'Did you mean' country data. 
@@ -88,7 +88,7 @@ Returns a Hash 'searchedData' with the following keys:
 			end
 		end
 		# This json call is pulling the total budget list based on the 'recipient_regions' string previously created
-		oipa_selected_regions_budget = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&reporting_organisation=GB-GOV-1&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}&group_by=recipient_region&aggregations=budget&recipient_region="+recipient_regions
+		oipa_selected_regions_budget = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&reporting_organisation=GB-GOV-1&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}&activity_status=2&group_by=recipient_region&aggregations=budget&recipient_region="+recipient_regions
 		regions_project_budget = JSON.parse_nil(oipa_selected_regions_budget) # Parsed the returned json data and storing it as a hash
 		# This check is necessary to make sure if there really exists a DFID region list matching with the search query else won't try to 
 		# parse and store budget data for the 'Did you mean' region data.
@@ -104,7 +104,7 @@ Returns a Hash 'searchedData' with the following keys:
 		# Sample Api call - http://&fields=activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation
 		# The following api call returns the projects list based on the search query. The result is returned with data sorted
 		# by budget value so that we can get the budget higher bound from a single api call.
-		oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&page_size=10&fields=aggregations,descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation&q=#{query}&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&reporting_organisation_startswith=GB"
+		oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&page_size=10&fields=aggregations,descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation&q=#{query}&activity_status=2&ordering=-activity_plus_child_budget_value&reporting_organisation_startswith=GB"
 		projects_list= JSON.parse(oipa_project_list)
 		searchedData['projects'] = projects_list['results'] # Storing the returned project list
 		# Checking if the returned result count is 0 or not. If not, then store the budget value of the first item from the returned search data.
@@ -115,7 +115,7 @@ Returns a Hash 'searchedData' with the following keys:
 		end
 		searchedData['project_count'] = projects_list['count'] # Stored the project count here
 		# This returns the relevant sector list to populate the left hand side sectors filter.
-		sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&q=#{query}&reporting_organisation_startswith=GB"
+		sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&q=#{query}&reporting_organisation_startswith=GB&activity_status=2"
 		searchedData['highLevelSectorList'] = high_level_sector_list_filter( sectorValuesJSON) # Returns the high level sector data with name and codes
 		#puts searchedData['highLevelSectorList']
 		searchedData['highLevelSectorList'] = searchedData['highLevelSectorList'].sort_by {|key| key}
@@ -124,7 +124,7 @@ Returns a Hash 'searchedData' with the following keys:
 		searchedData['actualStartDate'] = '1990-01-01T00:00:00'
 		searchedData['plannedEndDate'] = '2100-01-01T00:00:00'
 		# Pulling json data with an order by on actual start date to get the starting bound for the LHS date range slider. 
-		searchedData['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&hierarchy=1&q=#{query}&ordering=actual_start_date&start_date_gte=1900-01-02"
+		searchedData['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&hierarchy=1&q=#{query}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
 		searchedData['actualStartDate'] = JSON.parse(searchedData['actualStartDate'])
 		if(searchedData['actualStartDate']['count'] > 0)
 			tempStartDate = searchedData['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '2'}.first
@@ -140,7 +140,7 @@ Returns a Hash 'searchedData' with the following keys:
 		#	searchedData['actualStartDate'] = searchedData['actualStartDate']['results'][0]['activity_dates'][1]['iso_date']
 		#end
 		# Pulling json data with an order by on planned end date (DSC) to get the ending bound for the LHS date range slider. 
-		searchedData['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&hierarchy=1&q=#{query}&ordering=-planned_end_date&end_date_isnull=False"
+		searchedData['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&hierarchy=1&q=#{query}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
 		searchedData['plannedEndDate'] = JSON.parse(searchedData['plannedEndDate'])
 		#puts "activities/?format=json&page_size=1&fields=activity_dates&hierarchy=1&q=#{query}&ordering=-planned_end_date&end_date_isnull=False"
 		if(searchedData['plannedEndDate']['count'] > 0)
@@ -162,14 +162,14 @@ Returns a Hash 'searchedData' with the following keys:
 		#	end
 		#end
 		#This code is created for generating the left hand side document type filter list
-		oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&q=#{query}"
+		oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&q=#{query}&activity_status=2"
 		document_type_list = JSON.parse(oipa_document_type_list)
 		searchedData['document_types'] = document_type_list['results']
 		searchedData['document_types'] = searchedData['document_types'].sort_by {|key| key["document_link_category"]["name"]}
 
 		#Implementing org type filters
 		participatingOrgInfo = JSON.parse(File.read('data/participatingOrgList.json'))
-		oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&q=#{query}&hierarchy=1"
+		oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&q=#{query}&hierarchy=1&activity_status=2"
 		implementingOrg_type_list = JSON.parse(oipa_implementingOrg_type_list)
 		searchedData['implementingOrg_types'] = implementingOrg_type_list['results']
 		searchedData['implementingOrg_types'].each do |implementingOrgs|

--- a/helpers/sector_helpers.rb
+++ b/helpers/sector_helpers.rb
@@ -150,21 +150,21 @@ module SectorHelpers
 	 end
 
 	def get_sector_projects(n)
-		oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}"
+		oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}"
 		projects= JSON.parse(oipa_project_list)
 		results = {}
-		sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}"
+		sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
 		results['highLevelSectorList'] = high_level_sector_list_filter(sectorValuesJSON)
 		#results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}")
-		results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}")
-		results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}")
+		results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}&activity_status=2")
+		results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}&activity_status=2")
 		results['project_budget_higher_bound'] = 0
 		results['actualStartDate'] = '1990-01-01T00:00:00' 
 		results['plannedEndDate'] = '2000-01-01T00:00:00'
 		unless projects['results'][0].nil?
 			results['project_budget_higher_bound'] = projects['results'][0]['aggregations']['activity_children']['budget_value']
 		end
-		results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02"
+		results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
 		results['actualStartDate'] = JSON.parse(results['actualStartDate'])
 		tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '2'}.first
 		if (tempStartDate.nil?)
@@ -176,7 +176,7 @@ module SectorHelpers
 		#unless results['actualStartDate']['results'][0].nil? 
 		#	results['actualStartDate'] = results['actualStartDate']['results'][0]['activity_dates'][1]['iso_date']
 		#end
-		results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False"
+		results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
 		results['plannedEndDate'] = JSON.parse(results['plannedEndDate'])
 		results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '3'}.first
 		results['plannedEndDate'] = results['plannedEndDate']['iso_date']
@@ -190,13 +190,13 @@ module SectorHelpers
 		#end
 		results['projects'] = projects
 		#This code is created for generating the left hand side document type filter list
-		oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}"
+		oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
 		document_type_list = JSON.parse(oipa_document_type_list)
 		results['document_types'] = document_type_list['results']
 
 		#Implementing org type filters
 		participatingOrgInfo = JSON.parse(File.read('data/participatingOrgList.json'))
-		oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}"
+		oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&activity_status=2"
 		implementingOrg_type_list = JSON.parse(oipa_implementingOrg_type_list)
 		results['implementingOrg_types'] = implementingOrg_type_list['results']
 		results['implementingOrg_types'].each do |implementingOrgs|

--- a/public/javascripts/searchPageFilters.js
+++ b/public/javascripts/searchPageFilters.js
@@ -205,7 +205,7 @@ $(document).ready(function() {
                 $.getJSON(pagedOipaLink,{
                     format: "json"
                 }).done(function(json){
-                    $('#showResults').html("");
+                    $('#showResults').html('<div class="ui-state-highlight ui-corner-all" style="margin-top: 20px; padding: 0.5em 0.7em 0em;"><p><span style="float: left; margin-right: .3em;" class="ui-icon ui-icon-info"></span>Default filter shows currently active projects. To see projects at other stages, use the status filters.</p></div>');
                     if (!isEmpty(json.next)){
                         var tmpStr = '<div>Now showing projects <span name="afterFilteringAmount" style="display:inline;"></span><span id="numberofResults" value="" style="display:inline;">'+(1+(10*(pageNumber-1)))+' - '+(10*pageNumber)+'</span> of '+projectCount+'</div>';
                         $('#showResults').append(tmpStr);
@@ -280,7 +280,7 @@ $(document).ready(function() {
             format: "json"
         })
         .done(function(json){
-            $('#showResults').html("");
+            $('#showResults').html('<div class="ui-state-highlight ui-corner-all" style="margin-top: 20px; padding: 0.5em 0.7em 0em;"><p><span style="float: left; margin-right: .3em;" class="ui-icon ui-icon-info"></span>Default filter shows currently active projects. To see projects at other stages, use the status filters.</p></div>');
             returnedProjectCount = json.count;
             refreshPagination(json.count);
             if (!isEmpty(json.next)){

--- a/views/countries/projects.html.erb
+++ b/views/countries/projects.html.erb
@@ -17,6 +17,6 @@
     </div>
 </div>
 
-<%= erb :'partials/_countries-tabs', :locals => { :active => "projects", :country => country, :project_count => total_projects, :results_count => results.length } %>
+<%= erb :'partials/_countries-tabs', :locals => { :active => "projects", :country => country, :project_count => projectCount, :results_count => results.length } %>
 
 <%= erb :'partials/_project_list', :locals => { :projects => projects, :country => country, :project_count => total_projects, :countryAllProjectFilters => countryAllProjectFilters, :highLevelSectorList => highLevelSectorList, :oipa_api_url => oipa_api_url, :total_projects => total_projects, :budgetHigherBound => budgetHigherBound, :actualStartDate => actualStartDate, :plannedEndDate => plannedEndDate, :documentTypes => documentTypes, :implementingOrgTypes => implementingOrgTypes} %>

--- a/views/partials/_countries-tabs.html.erb
+++ b/views/partials/_countries-tabs.html.erb
@@ -7,7 +7,7 @@
                     <nav>
                         <ul class="tab-bar">
                             <li <%= active=="summary" ? "class='active'" : ""%>><a href="/countries/<%= country[:code] %>">Summary</a></li>
-                            <li <%= active=="projects" ? "class='active'" : ""%>><a href="/countries/<%= country[:code] %>/projects">All Projects (<%=project_count%>)</a></li>
+                            <li <%= active=="projects" ? "class='active'" : ""%>><a href="/countries/<%= country[:code] %>/projects">Active Projects (<%=project_count%>)</a></li>
                             <%if results_count > 0 %>
                             <li <%= active=="results" ? "class='active'" : ""%>><a href="/countries/<%= country[:code] %>/results">Results</a></li>
                             <% end %>

--- a/views/partials/_project_list.html.erb
+++ b/views/partials/_project_list.html.erb
@@ -25,6 +25,7 @@
                 <div><div>Loading Data <br> Please Wait</div></div>
             </div>
             <div id="showResults">
+                <div class="ui-state-highlight ui-corner-all" style="margin-top: 20px; padding: 0.5em 0.7em 0em;"><p><span style="float: left; margin-right: .3em;" class="ui-icon ui-icon-info"></span>Default filter shows currently active projects. To see projects at other stages, use the status filters.</p></div>
                 <div>
                     Now showing projects <span name="afterFilteringAmount" style="display:inline;"></span>
                     <% if (project_count > 10) %><span id="numberofResults" value="" style="display:inline;">1 - 10</span> of <%= project_count%>
@@ -85,11 +86,19 @@
                     <div class="mContent">
                         <ul style="display: none; margin: 5px">
                             <% countryAllProjectFilters["activity_status"].each do |statuses| %>
-                            <li>
-                                <label for="activity_status_<%= statuses["code"] %>" title=" <%= statuses["name"] %>">
-                                <input id="activity_status_<%= statuses["code"] %>" type="checkbox" value="<%= statuses["code"] %>" class="activity_status" name="status"><%= statuses["name"] %>
-                                </label>
-                            </li>
+                                <%if statuses["code"] == '2' %>
+                                    <li>
+                                        <label for="activity_status_<%= statuses["code"] %>" title=" <%= statuses["name"] %>">
+                                        <input id="activity_status_<%= statuses["code"] %>" type="checkbox" value="<%= statuses["code"] %>" class="activity_status" checked name="status"><%= statuses["name"] %>
+                                        </label>
+                                    </li>
+                                <%else%>
+                                    <li>
+                                        <label for="activity_status_<%= statuses["code"] %>" title=" <%= statuses["name"] %>">
+                                        <input id="activity_status_<%= statuses["code"] %>" type="checkbox" value="<%= statuses["code"] %>" class="activity_status" name="status"><%= statuses["name"] %>
+                                        </label>
+                                    </li>
+                                <%end%>
                             <% end %>
                         </ul>
                     </div>

--- a/views/partials/_project_list.html.erb
+++ b/views/partials/_project_list.html.erb
@@ -102,7 +102,7 @@
                             <% end %>
                         </ul>
                     </div>
-                    <input type="hidden" id="activity_status_states" value="1,2,3,4,5"  />
+                    <input type="hidden" id="activity_status_states" value="2"  />
                 </div>
                 <% if defined? sectorData %>
                     <div class="filter-header" name="locations" style="background: none repeat scroll 0px 0px rgb(244, 244, 244); padding: 5px 0px 0px 5px;">

--- a/views/partials/_regions-summary-tabs.html.erb
+++ b/views/partials/_regions-summary-tabs.html.erb
@@ -6,7 +6,7 @@
                 <div class="projects-nav six columns">
                     <nav>
                         <ul class="tab-bar">
-                            <li <%= active=="projects" ? "class='active'" : ""%>><a href="/regions/<%= region[:code] %>/projects">All Projects (<%=project_count%>)</a></li>
+                            <li <%= active=="projects" ? "class='active'" : ""%>><a href="/regions/<%= region[:code] %>/projects">Active Projects (<%=project_count%>)</a></li>
                         </ul>
                     </nav>
                 </div>  

--- a/views/partials/_regions-tabs.html.erb
+++ b/views/partials/_regions-tabs.html.erb
@@ -7,7 +7,7 @@
                     <nav>
                         <ul class="tab-bar">
                             <li <%= active=="summary" ? "class='active'" : ""%>><a href="/regions/<%= region[:code] %>">Summary</a></li>
-                            <li <%= active=="projects" ? "class='active'" : ""%>><a href="/regions/<%= region[:code] %>/projects">All Projects (<%=project_count%>)</a></li>
+                            <li <%= active=="projects" ? "class='active'" : ""%>><a href="/regions/<%= region[:code] %>/projects">Active Projects (<%=project_count%>)</a></li>
                         </ul>
                     </nav>
                 </div>  

--- a/views/regions/projects-home.erb
+++ b/views/regions/projects-home.erb
@@ -21,5 +21,5 @@
     </div>
 </div>
 
-<%= erb :'partials/_regions-summary-tabs', :locals => { :active => "projects", :region => region, :project_count => total_projects} %>
+<%= erb :'partials/_regions-summary-tabs', :locals => { :active => "projects", :region => region, :project_count => projectCount} %>
 <%= erb :'partials/_project_list', :locals => { :projects => projects, :region => region, :project_count => total_projects, :countryAllProjectFilters => countryAllProjectFilters, :highLevelSectorList => highLevelSectorList, :oipa_api_url => oipa_api_url, :total_projects => total_projects, :budgetHigherBound => budgetHigherBound, :actualStartDate => actualStartDate, :plannedEndDate => plannedEndDate, :documentTypes => documentTypes, :implementingOrgTypes => implementingOrgTypes } %>

--- a/views/regions/projects.html.erb
+++ b/views/regions/projects.html.erb
@@ -21,5 +21,5 @@
     </div>
 </div>
 
-<%= erb :'partials/_regions-tabs', :locals => { :active => "projects", :region => region, :project_count => total_projects} %>
+<%= erb :'partials/_regions-tabs', :locals => { :active => "projects", :region => region, :project_count => projectCount} %>
 <%= erb :'partials/_project_list', :locals => { :projects => projects, :region => region, :project_count => total_projects, :countryAllProjectFilters => countryAllProjectFilters, :highLevelSectorList => highLevelSectorList, :oipa_api_url => oipa_api_url, :total_projects => total_projects, :budgetHigherBound => budgetHigherBound, :actualStartDate => actualStartDate, :plannedEndDate => plannedEndDate, :documentTypes => documentTypes, :implementingOrgTypes => implementingOrgTypes } %>

--- a/views/search/search.html.erb
+++ b/views/search/search.html.erb
@@ -88,6 +88,7 @@
                     <%end%>
                 </div>
                 <div id="showResults">
+                    <div class="ui-state-highlight ui-corner-all" style="margin-top: 20px; padding: 0.5em 0.7em 0em;"><p><span style="float: left; margin-right: .3em;" class="ui-icon ui-icon-info"></span>Default filter shows currently active projects. To see projects at other stages, use the status filters.</p></div>
                     <div>
                         Now showing projects <span name="afterFilteringAmount" style="display:inline;"></span>
                         <% if (project_count > 10) %><span id="numberofResults" value="" style="display:inline;">1 - 10</span> of <%= project_count%>
@@ -156,15 +157,23 @@
                         <div class="mContent">
                             <ul style="display: none; margin: 5px">
                                 <% countryAllProjectFilters["activity_status"].each do |statuses| %>
-                                <li>
-                                    <label for="activity_status_<%= statuses["code"] %>" title=" <%= statuses["name"] %>">
-                                    <input id="activity_status_<%= statuses["code"] %>" type="checkbox" value="<%= statuses["code"] %>" class="activity_status" name="status"><%= statuses["name"] %>
-                                    </label>
-                                </li>
+                                    <%if statuses["code"] == '2' %>
+                                        <li>
+                                            <label for="activity_status_<%= statuses["code"] %>" title=" <%= statuses["name"] %>">
+                                            <input id="activity_status_<%= statuses["code"] %>" type="checkbox" value="<%= statuses["code"] %>" class="activity_status" checked name="status"><%= statuses["name"] %>
+                                            </label>
+                                        </li>
+                                    <%else%>
+                                        <li>
+                                            <label for="activity_status_<%= statuses["code"] %>" title=" <%= statuses["name"] %>">
+                                            <input id="activity_status_<%= statuses["code"] %>" type="checkbox" value="<%= statuses["code"] %>" class="activity_status" name="status"><%= statuses["name"] %>
+                                            </label>
+                                        </li>
+                                    <%end%>
                                 <% end %>
                             </ul>
                         </div>
-                        <input type="hidden" id="activity_status_states" value="1,2,3,4,5"  />
+                        <input type="hidden" id="activity_status_states" value="2"  />
                     </div>
                     <div name="locations" style="display: none">
                         <h3>Locations</h3>


### PR DESCRIPTION
**devtracker.rb** - Added new project count of only the active projects.
**helpers/country_helpers.rb** - Updated code to show only active project data.
**helpers/region_helpers.rb** - Updated code to show only active project data.
**helpers/search_helper.rb** - Updated code to show only active project data.
**helpers/sector_helpers.rb** - Updated code to show only active project data.
**public/javascripts/searchPageFilters.js** - Stylize the information container that stored instruction on project status.
**views/countries/projects.html.erb** - Updated code to show only active project count instead of all project numbers.
**views/partials/_countries-tabs.html.erb** - Change text from 'all projects' to 'active projects'.
**views/partials/_project_list.html.erb** - Generate the template with 'implementing' status selected by default.
**views/partials/_regions-summary-tabs.html.erb** - Change text from 'all projects' to 'active projects'.
**views/partials/_regions-tabs.html.erb** - Change text from 'all projects' to 'active projects'.
**views/regions/projects-home.erb** - Updated code to show only active project count instead of all project numbers.
**views/regions/projects.html.erb** - Updated code to show only active project count instead of all project numbers.
**views/search/search.html.erb** - Generate the template with 'implementing' status selected by default.