### PR TITLE
Fix broken urls slashes

### DIFF
--- a/views/partials/_project_list.html.erb
+++ b/views/partials/_project_list.html.erb
@@ -37,7 +37,7 @@
                 <div class="search-result">
                     <h3>    
                         <%unless project['iati_identifier'].nil? %>
-                            <a href="/projects/<%= project['iati_identifier'].gsub(/\s+/, '') %>">
+                            <a href="/projects/<%= project['iati_identifier'].gsub(/\s+/, '').gsub(/\//,'-') %>">
                             <%unless project['title']['narratives'].nil? %>
                                 <%unless project['title']['narratives'][0]['text'].nil? %>
                                     <%=project['title']['narratives'][0]['text']%>

--- a/views/partials/_projects-header.html.erb
+++ b/views/partials/_projects-header.html.erb
@@ -51,3 +51,21 @@
         </div>
     </div>
 </div>
+
+<div class="row">
+    <div class="twelve columns">
+        <% if(!is_dfid_project(project['iati_identifier'])) %>
+        <div id="disclaimer" class="disclaimer grey">
+            <div style="margin-top: 0px; padding: 0.3em 0.0em 0em;" class="ui-state-highlight ui-corner-all">
+                <p style="margin-bottom: 0px; line-height: 1; font-size: 1em"><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span><strong>Disclaimer</strong>: The data for this page has been produced from IATI data published by <strong><%= project['reporting_organisations'][0]['narratives'][0]['text'] || "" %></strong>. 
+
+                <% if (!project['contact_info'][0].nil?) %>
+                    Please contact them (<%=project['contact_info'][0]['email'] %>) if you have any questions about their data.</p>
+                <% else %>
+                    Please contact them if you have any questions about their data.</p>
+                <% end %>
+            </div>
+        </div>
+        <% end %>
+    </div>
+</div>

--- a/views/projects/documents.html.erb
+++ b/views/projects/documents.html.erb
@@ -7,15 +7,6 @@
           <p>DFID aim to be as transparent as possible however, in some cases, we are unable to show all the documents that are associated with a project, for example where there is a potential security risk. Documents for projects approved before January 2011 are not normally published.</p>
         <% end %>
         <div class="row">
-    <div class="twelve columns">
-        <% if(!is_dfid_project(project['iati_identifier'])) %>
-        <div id="disclaimer" class="disclaimer grey">
-            <div style="margin-top: 0px; padding: 0.3em 0.0em 0em;" class="ui-state-highlight ui-corner-all">
-                <p style="margin-bottom: 0px; line-height: 1; font-size: 1em"><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span><strong>Disclaimer</strong>: The data for this page has been produced from IATI data published by <%= project['reporting_organisations'][0]['narratives'][0]['text'] || "" %>. Please contact them if you have any questions about their data.</p>
-            </div>
-        </div>
-        <% end %>
-    </div>
 </div>
         <table class="results-list">
             <thead class="visually-hidden">

--- a/views/projects/partners.html.erb
+++ b/views/projects/partners.html.erb
@@ -2,18 +2,6 @@
 
 <%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :active => "partners"} %>
 
-<div class="row">
-    <div class="twelve columns">
-        <% if(!is_dfid_project(project['iati_identifier'])) %>
-        <div id="disclaimer" class="disclaimer grey">
-            <div style="margin-top: 0px; padding: 0.3em 0.0em 0em;" class="ui-state-highlight ui-corner-all">
-                <p style="margin-bottom: 0px; line-height: 1; font-size: 1em"><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span><strong>Disclaimer</strong>: The data for this page has been produced from IATI data published by <%= project['reporting_organisations'][0]['narratives'][0]['text'] || "" %>. Please contact them if you have any questions about their data.</p>
-            </div>
-        </div>
-        <% end %>
-    </div>
-</div>
-
   <% if fundingProjectsCount > 0 then %>
       <div class="row">
           <div class="twelve columns results-info">

--- a/views/projects/summary.html.erb
+++ b/views/projects/summary.html.erb
@@ -2,19 +2,6 @@
 <%= erb :'partials/_projects-header', :locals => { :project => project, :countryOrRegion => countryOrRegion, :fundedProjectsCount => fundedProjectsCount, :fundingProjectsCount => fundingProjectsCount, :active => "summary"} %>
 
 <div class="row">
-    <div class="twelve columns">
-        <% if(!is_dfid_project(project['iati_identifier'])) %>
-        <div id="disclaimer" class="disclaimer grey">
-            <div style="margin-top: 0px; padding: 0.3em 0.0em 0em;" class="ui-state-highlight ui-corner-all">
-                <p style="margin-bottom: 0px; line-height: 1; font-size: 1em"><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span><strong>Disclaimer</strong>: The data for this page has been produced from IATI data published by <%= project['reporting_organisations'][0]['narratives'][0]['text'] || "" %>. Please contact them if you have any questions about their data.</p>
-            </div>
-        </div>
-        <% end %>
-    </div>
-</div>
-
-
-<div class="row">
     <div class="twelve columns summary">
         <p class="project-description"><%= project['descriptions'].length>0 ? project['descriptions'][0]['narratives'][0]['text'] : "" %></p>
     </div>

--- a/views/projects/transactions.html.erb
+++ b/views/projects/transactions.html.erb
@@ -8,15 +8,7 @@ title: Development Tracker
 <%#                       B U D G E T S   T A B L E                          %>
 <%# ------------------------------------------------------------------------ %>
 <div class="row">
-  <div class="twelve columns">
-      <% if(!is_dfid_project(project['iati_identifier'])) %>
-      <div id="disclaimer" class="disclaimer grey">
-          <div style="margin-top: 0px; padding: 0.3em 0.0em 0em;" class="ui-state-highlight ui-corner-all">
-              <p style="margin-bottom: 0px; line-height: 1; font-size: 1em"><span class="ui-icon ui-icon-info" style="float: left; margin-right: .3em;"></span><strong>Disclaimer</strong>: The data for this page has been produced from IATI data published by <%= project['reporting_organisations'][0]['narratives'][0]['text'] || "" %>. Please contact them if you have any questions about their data.</p>
-          </div>
-      </div>
-      <% end %>
-  </div>
+  
   <div class="twelve columns transactions">
 
     <div class="section-group-title trans-header-container">

--- a/views/search/search.html.erb
+++ b/views/search/search.html.erb
@@ -27,7 +27,7 @@
                             </label>
                         </div>
                         <div class="six columns">
-                            <input type="text" value="" placeholder="e.g. location, sector, organisation or keyword" name="query" id="query">
+                            <input type="text" value="<%= query %>" placeholder="e.g. location, sector, organisation or keyword" name="query" id="query">
                         </div>
                         <div class="three columns">
                             <input type="submit" class="button" value="Search">
@@ -334,7 +334,16 @@
     <%else%>
         <div class="row">
             <div class="twelve columns">
-                <div class="search-result nine columns push-three"><p style="padding-top:.33em">Your search - <b><em><%= query %></em></b> - did not match any documents.  </p><p style="margin-top:1em">Suggestions:</p><ul style="margin:0 0 2em;margin-left:1.3em; line-height: 3em; list-style: none"><li>Make sure all words are spelled correctly.</li><li>Try different keywords.</li><li>Try more general keywords.</li><li>Try fewer keywords.</li></ul></div>
+                <div class="search-result nine columns push-three">
+                    <p style="padding-top:.33em">Your search - <b><em><%= query %></em></b> - did not match any documents.  </p><p style="margin-top:1em">Suggestions:</p>
+                    <ul style="margin:0 0 2em;margin-left:1.3em; line-height: 3em; list-style: none">
+                        <li>Make sure all words are spelled correctly.</li>
+                        <li>Try different keywords.</li>
+                        <li>Try more general keywords.</li>
+                        <li>Try fewer keywords.</li>
+                    </ul>
+                    <p>Search results only show currently active projects. To see projects at other stages, first carry out a more general search and then use the status filters on the search results page.</p>
+                </div>
                 <div class="three columns pull-nine"></div>
             </div>
         </div>


### PR DESCRIPTION
Although a / character in an iati-identifier is illegal (it breaks URL structures) some parts of HMG still use it

FCO
Medical Research Council

As a temporary fix this builds on Gazi's urgent FCO fix from last week.

Branch fix-broken-url-slashes created and tested with FCO and MRC:

http://localhost:4567/medical-research-council (all files)
http://localhost:4567/projects/GB-3-A-02694 (slash in iati-identifer)
