### PR TITLE
replaced / with - in urls for illegal iati-identifiers

### DIFF
--- a/views/partials/_project_list.html.erb
+++ b/views/partials/_project_list.html.erb
@@ -37,7 +37,7 @@
                 <div class="search-result">
                     <h3>    
                         <%unless project['iati_identifier'].nil? %>
-                            <a href="/projects/<%= project['iati_identifier'].gsub(/\s+/, '') %>">
+                            <a href="/projects/<%= project['iati_identifier'].gsub(/\s+/, '').gsub(/\//, '-') %>">
                             <%unless project['title']['narratives'].nil? %>
                                 <%unless project['title']['narratives'][0]['text'].nil? %>
                                     <%=project['title']['narratives'][0]['text']%>


### PR DESCRIPTION
Although a / character in an iati-identifier is illegal (it breaks URL structures) some parts of HMG still use it

FCO
Medical Research Council

As a temporary fix this builds on Gazi's urgent FCO fix from last week.

Branch fix-broken-url-slashes created and tested with FCO and MRC:

http://localhost:4567/medical-research-council (all files)
http://localhost:4567/projects/GB-3-A-02694 (slash in iati-identifer)
