### PR TITLE
T622 separate 404 500 error messages

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -327,7 +327,7 @@ end
 # Project summary page
 get '/projects/:proj_id/?' do |n|
 	n = sanitize_input(n,"p")
-
+	check_if_project_exists(n)
 	# get the project data from the API
   	project = get_h1_project_details(n)
 

--- a/helpers/project_helpers.rb
+++ b/helpers/project_helpers.rb
@@ -8,6 +8,15 @@ module ProjectHelpers
     include CodeLists
     include CommonHelpers
 
+    def check_if_project_exists(projectId)
+        begin
+            oipa = RestClient.get settings.oipa_api_url + "activities/#{projectId}/?format=json"
+        rescue => e
+            halt 404, "Activity not found"
+        end
+        return true
+    end
+
     def get_h1_project_details(projectId)
         oipa = RestClient.get settings.oipa_api_url + "activities/#{projectId}/?format=json"
         project = JSON.parse(oipa)


### PR DESCRIPTION
**devtracker.rb** - Added a method that checks if the project exists or not. If it doesn't, then the page redirects to a 404 item not found page. Else, for other issues, it redirects to a 500 internal error page.

**helpers/project_helpers.rb** - Added a new function that checks if the api returns any data for a specific activity or not. If it does not return the data, then the method redirects to a 404 item not found page. Else loads the page as usual.