### PR TITLE
Remove additional / from the totalCountryBudgetLocation variable

### DIFF
--- a/helpers/country_helpers.rb
+++ b/helpers/country_helpers.rb
@@ -419,7 +419,7 @@ module CountryHelpers
     #oipa 2.2
     #totalCountryBudgetLocation = RestClient.get settings.oipa_api_url + "activities/aggregations/?reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=budget&budget_period_start=#{firstDayOfFinYear}&budget_period_end=#{lastDayOfFinYear}&order_by=-budget&format=json"
     #oipa 3.1
-    totalCountryBudgetLocation = RestClient.get settings.oipa_api_url + "/budgets/aggregations/?reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=value&budget_period_start=#{firstDayOfFinYear}&budget_period_end=#{lastDayOfFinYear}&format=json&order_by=-value"
+    totalCountryBudgetLocation = RestClient.get settings.oipa_api_url + "budgets/aggregations/?reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=value&budget_period_start=#{firstDayOfFinYear}&budget_period_end=#{lastDayOfFinYear}&format=json&order_by=-value"
     totalCountryBudgetLocation = JSON.parse(totalCountryBudgetLocation)
     totalAmount = 0.0
     totalCountryBudgetLocation['results'].each do |countryBudgets|


### PR DESCRIPTION
The fix was put in place to stop the issues with the locally hosted OIPA environment which does not automatically filter out double slashes in API calls. 