### PR TITLE
Bug 711 sector page 404 error

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -76,8 +76,8 @@ set :current_last_day_of_financial_year, last_day_of_financial_year(DateTime.now
 set :google_recaptcha_publicKey, ENV["GOOGLE_PUBLIC_KEY"]
 set :google_recaptcha_privateKey, ENV["GOOGLE_PRIVATE_KEY"]
 
-set :raise_errors, false
-set :show_exceptions, false
+set :raise_errors, true
+set :show_exceptions, true
 
 set :devtracker_page_title, ''
 #####################################################################

--- a/devtracker.rb
+++ b/devtracker.rb
@@ -54,13 +54,13 @@ include RecaptchaHelper
 include OGDHelper
 
 # Developer Machine: set global settings
-#set :oipa_api_url, 'https://devtracker.dfid.gov.uk/api/'
+set :oipa_api_url, 'https://devtracker.dfid.gov.uk/api/'
 #set :oipa_api_url, 'http://loadbalancer1-dfid.oipa.nl/api/'
 #set :oipa_api_url, 'https://staging-dfid.oipa.nl/api/'
 #set :oipa_api_url, 'https://dev-dfid.oipa.nl/api/'
 
 # Server Machine: set global settings to use varnish cache
-set :oipa_api_url, 'http://127.0.0.1:6081/api/'
+#set :oipa_api_url, 'http://127.0.0.1:6081/api/'
 
 #ensures that we can use the extension html.erb rather than just .erb
 Tilt.register Tilt::ERBTemplate, 'html.erb'
@@ -76,8 +76,8 @@ set :current_last_day_of_financial_year, last_day_of_financial_year(DateTime.now
 set :google_recaptcha_publicKey, ENV["GOOGLE_PUBLIC_KEY"]
 set :google_recaptcha_privateKey, ENV["GOOGLE_PRIVATE_KEY"]
 
-set :raise_errors, false
-set :show_exceptions, false
+set :raise_errors, true
+set :show_exceptions, true
 
 set :devtracker_page_title, ''
 #####################################################################

--- a/devtracker.rb
+++ b/devtracker.rb
@@ -54,13 +54,13 @@ include RecaptchaHelper
 include OGDHelper
 
 # Developer Machine: set global settings
-set :oipa_api_url, 'https://devtracker.dfid.gov.uk/api/'
+#set :oipa_api_url, 'https://devtracker.dfid.gov.uk/api/'
 #set :oipa_api_url, 'http://loadbalancer1-dfid.oipa.nl/api/'
 #set :oipa_api_url, 'https://staging-dfid.oipa.nl/api/'
 #set :oipa_api_url, 'https://dev-dfid.oipa.nl/api/'
 
 # Server Machine: set global settings to use varnish cache
-#set :oipa_api_url, 'http://127.0.0.1:6081/api/'
+set :oipa_api_url, 'http://127.0.0.1:6081/api/'
 
 #ensures that we can use the extension html.erb rather than just .erb
 Tilt.register Tilt::ERBTemplate, 'html.erb'
@@ -76,8 +76,8 @@ set :current_last_day_of_financial_year, last_day_of_financial_year(DateTime.now
 set :google_recaptcha_publicKey, ENV["GOOGLE_PUBLIC_KEY"]
 set :google_recaptcha_privateKey, ENV["GOOGLE_PRIVATE_KEY"]
 
-set :raise_errors, true
-set :show_exceptions, true
+set :raise_errors, false
+set :show_exceptions, false
 
 set :devtracker_page_title, ''
 #####################################################################

--- a/devtracker.rb
+++ b/devtracker.rb
@@ -76,8 +76,8 @@ set :current_last_day_of_financial_year, last_day_of_financial_year(DateTime.now
 set :google_recaptcha_publicKey, ENV["GOOGLE_PUBLIC_KEY"]
 set :google_recaptcha_privateKey, ENV["GOOGLE_PRIVATE_KEY"]
 
-set :raise_errors, true
-set :show_exceptions, true
+set :raise_errors, false
+set :show_exceptions, false
 
 set :devtracker_page_title, ''
 #####################################################################

--- a/helpers/sector_helpers.rb
+++ b/helpers/sector_helpers.rb
@@ -154,78 +154,146 @@ module SectorHelpers
 		oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}"
 		projects= JSON.parse(oipa_project_list)
 		results = {}
-		##sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
-		sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}"
-		results['highLevelSectorList'] = high_level_sector_list_filter(sectorValuesJSON)
-		#results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}")
-		##results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}&activity_status=2")
-		results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}")
-		##results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}&activity_status=2")
-		results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}")
-		results['project_budget_higher_bound'] = 0
-		results['actualStartDate'] = '1990-01-01T00:00:00' 
-		results['plannedEndDate'] = '2000-01-01T00:00:00'
-		unless projects['results'][0].nil?
-			results['project_budget_higher_bound'] = projects['results'][0]['aggregations']['activity_children']['budget_value']
-		end
-		##results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
-		results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02"
-		results['actualStartDate'] = JSON.parse(results['actualStartDate'])
-		tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '2'}.first
-		if (tempStartDate.nil?)
-		tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '1'}.first
-		end
-      	results['actualStartDate'] = tempStartDate
-      	results['actualStartDate'] = results['actualStartDate']['iso_date']
-
-		#unless results['actualStartDate']['results'][0].nil? 
-		#	results['actualStartDate'] = results['actualStartDate']['results'][0]['activity_dates'][1]['iso_date']
-		#end
-		##results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
-		results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False"
-		results['plannedEndDate'] = JSON.parse(results['plannedEndDate'])
-		results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '3'}.first
-		results['plannedEndDate'] = results['plannedEndDate']['iso_date']
-
-		#unless results['plannedEndDate']['results'][0].nil?
-		#	if !results['plannedEndDate']['results'][0]['activity_dates'][2].nil?
-		#		results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'][2]['iso_date']
-		#	else
-				#This is an issue. For now it's a temporary remedy used to avoid a ruby error but, this needs to be fixed once zz helps out with the api call to return the actual/planned end date.
-		#		results['plannedEndDate'] = '2050-12-31T00:00:00'
-		#	end
-		#end
-		results['projects'] = projects
-		#This code is created for generating the left hand side document type filter list
-		##oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
-		oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}"
-		document_type_list = JSON.parse(oipa_document_type_list)
-		results['document_types'] = document_type_list['results']
-
-		#Implementing org type filters
-		participatingOrgInfo = JSON.parse(File.read('data/participatingOrgList.json'))
-		##oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&activity_status=2"
-		oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}"
-		implementingOrg_type_list = JSON.parse(oipa_implementingOrg_type_list)
-		results['implementingOrg_types'] = implementingOrg_type_list['results']
-		results['implementingOrg_types'].each do |implementingOrgs|
-			if implementingOrgs['participating_organisation'].length < 1
-				tempImplmentingOrgData = participatingOrgInfo.select{|implementingOrg| implementingOrg['Code'].to_s == implementingOrgs['participating_organisation_ref'].to_s}.first
-		   		if tempImplmentingOrgData.nil?
-		   			implementingOrgs['participating_organisation'] = 'na'
-		   			implementingOrgs['participating_organisation_ref'] = 'na'
-		   		else
-		   			implementingOrgs['participating_organisation'] = tempImplmentingOrgData['Name']
-		   		end
+		if projects['results'][0].nil?
+			##sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
+			sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}"
+			results['highLevelSectorList'] = high_level_sector_list_filter(sectorValuesJSON)
+			#results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}")
+			##results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}&activity_status=2")
+			results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}")
+			##results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}&activity_status=2")
+			results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}")
+			results['project_budget_higher_bound'] = 0
+			results['actualStartDate'] = '1990-01-01T00:00:00' 
+			results['plannedEndDate'] = '2000-01-01T00:00:00'
+			unless projects['results'][0].nil?
+				results['project_budget_higher_bound'] = projects['results'][0]['aggregations']['activity_children']['budget_value']
 			end
-		end
-		results['LocationCountries'] = results['LocationCountries']['results']
-		results['LocationCountries'] = results['LocationCountries'].sort_by {|key| key["recipient_country"]["name"]}
-		results['LocationRegions'] = results['LocationRegions']['results']
-		results['LocationRegions'] = results['LocationRegions'].sort_by {|key| key["recipient_region"]["name"]}
-		results['highLevelSectorList'] = results['highLevelSectorList'].sort_by {|key| key}
-    	results['document_types'] = results['document_types'].sort_by {|key| key["document_link_category"]["name"]}
-    	results['implementingOrg_types'] = results['implementingOrg_types'].sort_by {|key| key["participating_organisation"]}.uniq{|key| key["participating_organisation_ref"]}
+			##results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
+			results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02"
+			results['actualStartDate'] = JSON.parse(results['actualStartDate'])
+			tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '2'}.first
+			if (tempStartDate.nil?)
+			tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '1'}.first
+			end
+	      	results['actualStartDate'] = tempStartDate
+	      	results['actualStartDate'] = results['actualStartDate']['iso_date']
+
+			#unless results['actualStartDate']['results'][0].nil? 
+			#	results['actualStartDate'] = results['actualStartDate']['results'][0]['activity_dates'][1]['iso_date']
+			#end
+			##results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
+			results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False"
+			results['plannedEndDate'] = JSON.parse(results['plannedEndDate'])
+			results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '3'}.first
+			results['plannedEndDate'] = results['plannedEndDate']['iso_date']
+
+			#unless results['plannedEndDate']['results'][0].nil?
+			#	if !results['plannedEndDate']['results'][0]['activity_dates'][2].nil?
+			#		results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'][2]['iso_date']
+			#	else
+					#This is an issue. For now it's a temporary remedy used to avoid a ruby error but, this needs to be fixed once zz helps out with the api call to return the actual/planned end date.
+			#		results['plannedEndDate'] = '2050-12-31T00:00:00'
+			#	end
+			#end
+			results['projects'] = projects
+			#This code is created for generating the left hand side document type filter list
+			##oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
+			oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}"
+			document_type_list = JSON.parse(oipa_document_type_list)
+			results['document_types'] = document_type_list['results']
+
+			#Implementing org type filters
+			participatingOrgInfo = JSON.parse(File.read('data/participatingOrgList.json'))
+			##oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&activity_status=2"
+			oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}"
+			implementingOrg_type_list = JSON.parse(oipa_implementingOrg_type_list)
+			results['implementingOrg_types'] = implementingOrg_type_list['results']
+			results['implementingOrg_types'].each do |implementingOrgs|
+				if implementingOrgs['participating_organisation'].length < 1
+					tempImplmentingOrgData = participatingOrgInfo.select{|implementingOrg| implementingOrg['Code'].to_s == implementingOrgs['participating_organisation_ref'].to_s}.first
+			   		if tempImplmentingOrgData.nil?
+			   			implementingOrgs['participating_organisation'] = 'na'
+			   			implementingOrgs['participating_organisation_ref'] = 'na'
+			   		else
+			   			implementingOrgs['participating_organisation'] = tempImplmentingOrgData['Name']
+			   		end
+				end
+			end
+			results['LocationCountries'] = results['LocationCountries']['results']
+			results['LocationCountries'] = results['LocationCountries'].sort_by {|key| key["recipient_country"]["name"]}
+			results['LocationRegions'] = results['LocationRegions']['results']
+			results['LocationRegions'] = results['LocationRegions'].sort_by {|key| key["recipient_region"]["name"]}
+			results['highLevelSectorList'] = results['highLevelSectorList'].sort_by {|key| key}
+	    	results['document_types'] = results['document_types'].sort_by {|key| key["document_link_category"]["name"]}
+	    	results['implementingOrg_types'] = results['implementingOrg_types'].sort_by {|key| key["participating_organisation"]}.uniq{|key| key["participating_organisation_ref"]}
+	    else
+			sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
+			results['highLevelSectorList'] = high_level_sector_list_filter(sectorValuesJSON)
+			#results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}")
+			results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}&activity_status=2")
+			results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}&activity_status=2")
+			results['project_budget_higher_bound'] = 0
+			results['actualStartDate'] = '1990-01-01T00:00:00' 
+			results['plannedEndDate'] = '2000-01-01T00:00:00'
+			unless projects['results'][0].nil?
+				results['project_budget_higher_bound'] = projects['results'][0]['aggregations']['activity_children']['budget_value']
+			end
+			results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
+			results['actualStartDate'] = JSON.parse(results['actualStartDate'])
+			tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '2'}.first
+			if (tempStartDate.nil?)
+			tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '1'}.first
+			end
+	      	results['actualStartDate'] = tempStartDate
+	      	results['actualStartDate'] = results['actualStartDate']['iso_date']
+
+			#unless results['actualStartDate']['results'][0].nil? 
+			#	results['actualStartDate'] = results['actualStartDate']['results'][0]['activity_dates'][1]['iso_date']
+			#end
+			results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
+			results['plannedEndDate'] = JSON.parse(results['plannedEndDate'])
+			results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '3'}.first
+			results['plannedEndDate'] = results['plannedEndDate']['iso_date']
+
+			#unless results['plannedEndDate']['results'][0].nil?
+			#	if !results['plannedEndDate']['results'][0]['activity_dates'][2].nil?
+			#		results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'][2]['iso_date']
+			#	else
+					#This is an issue. For now it's a temporary remedy used to avoid a ruby error but, this needs to be fixed once zz helps out with the api call to return the actual/planned end date.
+			#		results['plannedEndDate'] = '2050-12-31T00:00:00'
+			#	end
+			#end
+			results['projects'] = projects
+			#This code is created for generating the left hand side document type filter list
+			oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
+			document_type_list = JSON.parse(oipa_document_type_list)
+			results['document_types'] = document_type_list['results']
+
+			#Implementing org type filters
+			participatingOrgInfo = JSON.parse(File.read('data/participatingOrgList.json'))
+			oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&activity_status=2"
+			implementingOrg_type_list = JSON.parse(oipa_implementingOrg_type_list)
+			results['implementingOrg_types'] = implementingOrg_type_list['results']
+			results['implementingOrg_types'].each do |implementingOrgs|
+				if implementingOrgs['participating_organisation'].length < 1
+					tempImplmentingOrgData = participatingOrgInfo.select{|implementingOrg| implementingOrg['Code'].to_s == implementingOrgs['participating_organisation_ref'].to_s}.first
+			   		if tempImplmentingOrgData.nil?
+			   			implementingOrgs['participating_organisation'] = 'na'
+			   			implementingOrgs['participating_organisation_ref'] = 'na'
+			   		else
+			   			implementingOrgs['participating_organisation'] = tempImplmentingOrgData['Name']
+			   		end
+				end
+			end
+			results['LocationCountries'] = results['LocationCountries']['results']
+			results['LocationCountries'] = results['LocationCountries'].sort_by {|key| key["recipient_country"]["name"]}
+			results['LocationRegions'] = results['LocationRegions']['results']
+			results['LocationRegions'] = results['LocationRegions'].sort_by {|key| key["recipient_region"]["name"]}
+			results['highLevelSectorList'] = results['highLevelSectorList'].sort_by {|key| key}
+	    	results['document_types'] = results['document_types'].sort_by {|key| key["document_link_category"]["name"]}
+	    	results['implementingOrg_types'] = results['implementingOrg_types'].sort_by {|key| key["participating_organisation"]}.uniq{|key| key["participating_organisation_ref"]}
+	    end
 		return results
 	end
 end

--- a/helpers/sector_helpers.rb
+++ b/helpers/sector_helpers.rb
@@ -167,22 +167,31 @@ module SectorHelpers
 		unless projects['results'][0].nil?
 			results['project_budget_higher_bound'] = projects['results'][0]['aggregations']['activity_children']['budget_value']
 		end
-		results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
-		results['actualStartDate'] = JSON.parse(results['actualStartDate'])
-		tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '2'}.first
-		if (tempStartDate.nil?)
-		tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '1'}.first
+		begin
+			results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
+			results['actualStartDate'] = JSON.parse(results['actualStartDate'])
+			tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '2'}.first
+			if (tempStartDate.nil?)
+			tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '1'}.first
+			end
+	      	results['actualStartDate'] = tempStartDate
+	      	results['actualStartDate'] = results['actualStartDate']['iso_date']
+		rescue
+			results['actualStartDate'] = '1990-01-01T00:00:00'
 		end
-      	results['actualStartDate'] = tempStartDate
-      	results['actualStartDate'] = results['actualStartDate']['iso_date']
 
 		#unless results['actualStartDate']['results'][0].nil? 
 		#	results['actualStartDate'] = results['actualStartDate']['results'][0]['activity_dates'][1]['iso_date']
 		#end
-		results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
-		results['plannedEndDate'] = JSON.parse(results['plannedEndDate'])
-		results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '3'}.first
-		results['plannedEndDate'] = results['plannedEndDate']['iso_date']
+		begin
+			results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
+			results['plannedEndDate'] = JSON.parse(results['plannedEndDate'])
+			results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '3'}.first
+			results['plannedEndDate'] = results['plannedEndDate']['iso_date']
+		rescue
+			results['plannedEndDate'] = '2000-01-01T00:00:00'
+		end
+
 		#unless results['plannedEndDate']['results'][0].nil?
 		#	if !results['plannedEndDate']['results'][0]['activity_dates'][2].nil?
 		#		results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'][2]['iso_date']

--- a/helpers/sector_helpers.rb
+++ b/helpers/sector_helpers.rb
@@ -151,22 +151,25 @@ module SectorHelpers
 	 end
 
 	def get_sector_projects(n)
-		puts settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}"
-		oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}"
+		oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}"
 		projects= JSON.parse(oipa_project_list)
 		results = {}
-		sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
+		##sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
+		sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}"
 		results['highLevelSectorList'] = high_level_sector_list_filter(sectorValuesJSON)
 		#results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation&activity_status=1,2,3,4,5&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}")
-		results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}&activity_status=2")
-		results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}&activity_status=2")
+		##results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}&activity_status=2")
+		results['LocationCountries'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_country&aggregations=count&related_activity_sector=#{n}")
+		##results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}&activity_status=2")
+		results['LocationRegions'] = JSON.parse(RestClient.get settings.oipa_api_url + "activities/aggregations/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&group_by=recipient_region&aggregations=count&related_activity_sector=#{n}")
 		results['project_budget_higher_bound'] = 0
 		results['actualStartDate'] = '1990-01-01T00:00:00' 
 		results['plannedEndDate'] = '2000-01-01T00:00:00'
 		unless projects['results'][0].nil?
 			results['project_budget_higher_bound'] = projects['results'][0]['aggregations']['activity_children']['budget_value']
 		end
-		results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
+		##results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02&activity_status=2"
+		results['actualStartDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=actual_start_date&start_date_gte=1900-01-02"
 		results['actualStartDate'] = JSON.parse(results['actualStartDate'])
 		tempStartDate = results['actualStartDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '2'}.first
 		if (tempStartDate.nil?)
@@ -178,7 +181,8 @@ module SectorHelpers
 		#unless results['actualStartDate']['results'][0].nil? 
 		#	results['actualStartDate'] = results['actualStartDate']['results'][0]['activity_dates'][1]['iso_date']
 		#end
-		results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
+		##results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False&activity_status=2"
+		results['plannedEndDate'] = RestClient.get settings.oipa_api_url + "activities/?format=json&page_size=1&fields=activity_dates&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&ordering=-planned_end_date&end_date_isnull=False"
 		results['plannedEndDate'] = JSON.parse(results['plannedEndDate'])
 		results['plannedEndDate'] = results['plannedEndDate']['results'][0]['activity_dates'].select{|activityDate| activityDate['type']['code'] == '3'}.first
 		results['plannedEndDate'] = results['plannedEndDate']['iso_date']
@@ -193,13 +197,15 @@ module SectorHelpers
 		#end
 		results['projects'] = projects
 		#This code is created for generating the left hand side document type filter list
-		oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
+		##oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"
+		oipa_document_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=document_link_category&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}"
 		document_type_list = JSON.parse(oipa_document_type_list)
 		results['document_types'] = document_type_list['results']
 
 		#Implementing org type filters
 		participatingOrgInfo = JSON.parse(File.read('data/participatingOrgList.json'))
-		oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&activity_status=2"
+		##oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}&activity_status=2"
+		oipa_implementingOrg_type_list = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation=GB-GOV-1&hierarchy=1&related_activity_sector=#{n}"
 		implementingOrg_type_list = JSON.parse(oipa_implementingOrg_type_list)
 		results['implementingOrg_types'] = implementingOrg_type_list['results']
 		results['implementingOrg_types'].each do |implementingOrgs|

--- a/helpers/sector_helpers.rb
+++ b/helpers/sector_helpers.rb
@@ -26,7 +26,7 @@ module SectorHelpers
 	def get_5_dac_sector_data()
 		firstDayOfFinYear = first_day_of_financial_year(DateTime.now)
       	lastDayOfFinYear = last_day_of_financial_year(DateTime.now)
-		sectorValuesJSON = RestClient.get settings.oipa_api_url + "budgets/aggregations/?reporting_organisation=GB-GOV-1&group_by=sector&aggregations=value&budget_period_start=#{firstDayOfFinYear}&budget_period_end=#{lastDayOfFinYear}&format=json&activity_status=2"
+		sectorValuesJSON = RestClient.get settings.oipa_api_url + "budgets/aggregations/?reporting_organisation=GB-GOV-1&group_by=sector&aggregations=value&budget_period_start=#{firstDayOfFinYear}&budget_period_end=#{lastDayOfFinYear}&format=json"
 	end
 	
 	def group_hashes arr, group_fields
@@ -87,7 +87,7 @@ module SectorHelpers
 
 	# Return all of the DAC Sector codes associated with the parent sector code	- can be used for 3 digit (category) or 5 digit sector codes
 	def sector_parent_data_list(apiUrl, pageType, code, description, parentCodeType, parentDescriptionType, urlHighLevelSectorCode, urlCategoryCode)
-		sectorValuesJSON = RestClient.get apiUrl + "budgets/aggregations/?reporting_organisation=GB-GOV-1&group_by=sector&aggregations=value&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}&format=json&activity_status=2"
+		sectorValuesJSON = RestClient.get apiUrl + "budgets/aggregations/?reporting_organisation=GB-GOV-1&group_by=sector&aggregations=value&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}&format=json"
  		sectorValues  = JSON.parse(sectorValuesJSON)
   		sectorValues  = sectorValues['results']
   		sectorHierarchy = JSON.parse(File.read('data/sectorHierarchies.json'))
@@ -151,7 +151,8 @@ module SectorHelpers
 	 end
 
 	def get_sector_projects(n)
-		oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}"
+		puts settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}"
+		oipa_project_list = RestClient.get settings.oipa_api_url + "activities/?hierarchy=1&format=json&reporting_organisation=GB-GOV-1&page_size=10&fields=descriptions,activity_status,iati_identifier,url,title,reporting_organisations,activity_plus_child_aggregation,aggregations&activity_status=2&ordering=-activity_plus_child_budget_value&related_activity_sector=#{n}&budget_period_start=#{settings.current_first_day_of_financial_year}&budget_period_end=#{settings.current_last_day_of_financial_year}"
 		projects= JSON.parse(oipa_project_list)
 		results = {}
 		sectorValuesJSON = RestClient.get settings.oipa_api_url + "activities/aggregations/?format=json&group_by=sector&aggregations=count&reporting_organisation=GB-GOV-1&related_activity_sector=#{n}&activity_status=2"


### PR DESCRIPTION
The automated tests have highlighted that there is a 404 error in one of our DAC 5 digit sector pages: 15240 - Reintegration and SAWL control: ttps://devtracker.dfid.gov.uk/sector/4/categories/152/projects/15240

After discussion with Rumy he has updated the the code in sector_helpers.rb with the get_sector_projects(n) function to implement the following logic

Are there 0 projects returned
No - use the current API calls for results to populate the LHS JS filters with only live projects
Yes - use Rumy's updated API calls to populate the LHS JS filters with closed projects' data.

That way the LHS filters will be consistent with the returned data for 95% of cases (e.g when there are projects returned). When there's 0 it is obvious what to do to get the pages returned.

Test Cases

-- One active project returned, shows data in LHS filters is consistent for single project returns after the change when compared to live:

https://devtracker-int.dfid.gov.uk/sector/4/categories/152/projects/15261
https://devtracker-int.dfid.gov.uk/sector/11/categories/313/projects/31310

-- No active projects, shows that the 404 error no longer exists and we have a page users can interact with
https://devtracker-int.dfid.gov.uk/sector/4/categories/152/projects/15240

-- Many active projects returned for the sector, all appears correct
https://devtracker-int.dfid.gov.uk/sector/18/categories/720/projects/72010
