### PR TITLE
Added the budget sorting as default active sorting on all the active …

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -680,7 +680,7 @@ get '/search/?' do
 		activityStatusList = '1,2,3,4'
 	else
 		includeClosed = 0
-		activityStatusList = '1,2'
+		activityStatusList = '2'
 	end
 	puts activityStatusList
 	#results = generate_searched_data(query,activityStatusList)

--- a/views/partials/_project_list.html.erb
+++ b/views/partials/_project_list.html.erb
@@ -18,7 +18,7 @@
                     &nbsp;
                     <!-- Temporarily deactivating the sort by date option because of inconsistent data. --><!-- Start Date -->
                     <span class="sortProjSDate sort-proj-sectors" style="display:none;">▼</span>
-                    <input type="hidden" class="sort_results_type" value=""  />
+                    <input type="hidden" class="sort_results_type" value="-activity_plus_child_budget_value"  />
                 </div>
                 <div class="six columns">
                     <div class="light-pagination"></div>

--- a/views/partials/_project_list_dept.html.erb
+++ b/views/partials/_project_list_dept.html.erb
@@ -10,8 +10,8 @@
             <div class="row">
                 <div class="six columns">
                     <b>Sort results by:</b> Title <span id="sortProjTitle" class="sort-proj-sectors" style="display:inline;">▲</span> Budget <span id="sortProjBudg" class="sort-proj-sectors" style="display:inline;">▼</span> <!-- Temporarily deactivating the sort by date option because of inconsistent data. --><!-- Start Date --><span class="sortProjSDate sort-proj-sectors" style="display:none;">▼</span>
-                    <input type="hidden" class="sort_results_type" value=""  />
-                    <input type="hidden" id="sort_results_type" value=""  />
+                    <input type="hidden" class="sort_results_type" value="-activity_plus_child_budget_value"  />
+                    <input type="hidden" id="sort_results_type" value="-activity_plus_child_budget_value"  />
                 </div>
                 <div class="six columns">
                     <div class="light-pagination"></div>

--- a/views/search/search.html.erb
+++ b/views/search/search.html.erb
@@ -66,7 +66,7 @@
                 <div class="row">
                     <div class="five columns">
                         <b>Sort results by:</b> Title<span class="sortProjTitle sort-proj-sectors" style="display:inline;">▲</span> Budget<span class="sortProjBudg sort-proj-sectors" style="display:inline;">▼</span> <!-- Temporarily deactivating the sort by date option because of inconsistent data. --><!-- Start Date --><span class="sortProjSDate sort-proj-sectors" style="display:none;">▼</span>
-                        <input type="hidden" class="sort_results_type" value=""  />
+                        <input type="hidden" class="sort_results_type" value="-activity_plus_child_budget_value"  />
                     </div>
                     <div class="seven columns">
                         <div class="light-pagination"></div>


### PR DESCRIPTION
The requested code change automatically sorts the returned results according to budget in descending order. Which fixes the inconsistent project shuffling on the active projects page.