### PR TITLE
T1415 remove implementing partners tab v2

### DIFF
--- a/devtracker.rb
+++ b/devtracker.rb
@@ -68,8 +68,7 @@ Money.locale_backend = :i18n
 
 set :current_first_day_of_financial_year, first_day_of_financial_year(DateTime.now)
 set :current_last_day_of_financial_year, last_day_of_financial_year(DateTime.now)
-#set :goverment_department_ids, 'GB-GOV-15,GB-GOV-9,GB-GOV-6,GB-GOV-2,GB-GOV-1,GB-1,GB-GOV-3,GB-GOV-13,GB-GOV-7,GB-GOV-50,GB-GOV-52,GB-6,GB-10,GB-GOV-10,GB-9,GB-GOV-8,GB-GOV-5,GB-GOV-12,GB-COH-RC000346,GB-COH-03877777'
-set :goverment_department_ids, 'GB-GOV-1,GB-1'
+set :goverment_department_ids, 'GB-GOV-15,GB-GOV-9,GB-GOV-6,GB-GOV-2,GB-GOV-1,GB-1,GB-GOV-3,GB-GOV-13,GB-GOV-7,GB-GOV-50,GB-GOV-52,GB-6,GB-10,GB-GOV-10,GB-9,GB-GOV-8,GB-GOV-5,GB-GOV-12,GB-COH-RC000346,GB-COH-03877777'
 
 set :google_recaptcha_publicKey, ENV["GOOGLE_PUBLIC_KEY"]
 set :google_recaptcha_privateKey, ENV["GOOGLE_PRIVATE_KEY"]

--- a/devtracker.rb
+++ b/devtracker.rb
@@ -71,7 +71,8 @@ Money.locale_backend = :i18n
 
 set :current_first_day_of_financial_year, first_day_of_financial_year(DateTime.now)
 set :current_last_day_of_financial_year, last_day_of_financial_year(DateTime.now)
-set :goverment_department_ids, 'GB-GOV-15,GB-GOV-9,GB-GOV-6,GB-GOV-2,GB-GOV-1,GB-1,GB-GOV-3,GB-GOV-13,GB-GOV-7,GB-GOV-50,GB-GOV-52,GB-6,GB-10,GB-GOV-10,GB-9,GB-GOV-8,GB-GOV-5,GB-GOV-12,GB-COH-RC000346,GB-COH-03877777'
+#set :goverment_department_ids, 'GB-GOV-15,GB-GOV-9,GB-GOV-6,GB-GOV-2,GB-GOV-1,GB-1,GB-GOV-3,GB-GOV-13,GB-GOV-7,GB-GOV-50,GB-GOV-52,GB-6,GB-10,GB-GOV-10,GB-9,GB-GOV-8,GB-GOV-5,GB-GOV-12,GB-COH-RC000346,GB-COH-03877777'
+set :goverment_department_ids, 'GB-GOV-1,GB-1'
 
 set :google_recaptcha_publicKey, ENV["GOOGLE_PUBLIC_KEY"]
 set :google_recaptcha_privateKey, ENV["GOOGLE_PRIVATE_KEY"]

--- a/devtracker.rb
+++ b/devtracker.rb
@@ -53,10 +53,7 @@ include RecaptchaHelper
 
 # Developer Machine: set global settings
 #set :oipa_api_url, 'https://devtracker.dfid.gov.uk/api/'
-#set :oipa_api_url, 'http://loadbalancer1-dfid.oipa.nl/api/'
-#set :oipa_api_url, 'https://staging-dfid.oipa.nl/api/'
-#set :oipa_api_url, 'https://dev-dfid.oipa.nl/api/'
-#set :oipa_api_url, 'https://devtracker-entry.oipa.nl/api/'
+#set :oipa_api_url, 'https://devtracker-staging.oipa.nl/api/'
 
 # Server Machine: set global settings to use varnish cache
 set :oipa_api_url, 'http://127.0.0.1:6081/api/'
@@ -77,8 +74,8 @@ set :goverment_department_ids, 'GB-GOV-1,GB-1'
 set :google_recaptcha_publicKey, ENV["GOOGLE_PUBLIC_KEY"]
 set :google_recaptcha_privateKey, ENV["GOOGLE_PRIVATE_KEY"]
 
-set :raise_errors, true
-set :show_exceptions, true
+set :raise_errors, false
+set :show_exceptions, false
 
 set :devtracker_page_title, ''
 #####################################################################

--- a/devtracker.rb
+++ b/devtracker.rb
@@ -76,8 +76,8 @@ set :goverment_department_ids, 'GB-GOV-15,GB-GOV-9,GB-GOV-6,GB-GOV-2,GB-GOV-1,GB
 set :google_recaptcha_publicKey, ENV["GOOGLE_PUBLIC_KEY"]
 set :google_recaptcha_privateKey, ENV["GOOGLE_PRIVATE_KEY"]
 
-set :raise_errors, false
-set :show_exceptions, false
+set :raise_errors, true
+set :show_exceptions, true
 
 set :devtracker_page_title, ''
 #####################################################################
@@ -123,13 +123,13 @@ get '/countries/:country_code/?' do |n|
 			countrySectorGraphData = get_country_sector_graph_data(RestClient.get settings.oipa_api_url + "budgets/aggregations/?reporting_organisation_identifier=#{settings.goverment_department_ids}&order_by=-value&group_by=sector&aggregations=value&format=json&recipient_country=#{n}")
 	 	}
 	end
-	begin
-		implementingOrgURL = settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation_identifier=#{settings.goverment_department_ids}&recipient_country=#{n}&hierarchy=2&activity_status=2&participating_organisation_role=4"
-		implementingOrgList = JSON.parse(RestClient.get(implementingOrgURL))
-		implementingOrgList = implementingOrgList['results']
-	rescue
-		implementingOrgList = Array.new
-	end
+	#begin
+		#implementingOrgURL = settings.oipa_api_url + "activities/aggregations/?format=json&group_by=participating_organisation&aggregations=count&reporting_organisation_identifier=#{settings.goverment_department_ids}&recipient_country=#{n}&hierarchy=2&activity_status=2&participating_organisation_role=4"
+		#implementingOrgList = JSON.parse(RestClient.get(implementingOrgURL))
+		implementingOrgList = getCountryLevelImplOrgs(n,tempActivityCount['count'])
+	# rescue
+	# 	implementingOrgList = {}
+	# end
 	ogds = Oj.load(File.read('data/OGDs.json'))
 	topSixResults = pick_top_six_results(n)
 	#Geo Location data of country

--- a/helpers/country_helpers.rb
+++ b/helpers/country_helpers.rb
@@ -615,7 +615,6 @@ module CountryHelpers
     
   # Returns the country level implementing organisations
   def getCountryLevelImplOrgs(countryCode, activityCount)
-    puts settings.oipa_api_url + "activities/?format=json&recipient_country=#{countryCode}&fields=participating_organisations,recipient_countries,recipient_regions&reporting_organisation_identifier=#{settings.goverment_department_ids}&page_size=#{activityCount}&activity_status=2"
     allActivities = JSON.parse(RestClient.get settings.oipa_api_url + "activities/?format=json&recipient_country=#{countryCode}&fields=participating_organisations,recipient_countries,recipient_regions&reporting_organisation_identifier=#{settings.goverment_department_ids}&page_size=#{activityCount}&activity_status=2")
     allActivities = allActivities['results']
     implementingOrgs = {}

--- a/views/countries/country.html.erb
+++ b/views/countries/country.html.erb
@@ -116,8 +116,8 @@
         <div class="twelve columns">
             <span style="font-weight: bold;width: 100%;text-align: center;display: block;font-size: 1.7em;margin-bottom: 12px;">Implementing Partners (Beta)</span>
             <span>
-            <%implementingOrgList.each do |org|%>
-                <%=org['participating_organisation']%> (<%=org['count']%>) ¦
+            <%implementingOrgList.each do |key, val|%>
+                <%=val['orgName']%> (<%=val['count']%>) ¦
             <%end%>
             </span>
         </div>


### PR DESCRIPTION
Updated logic for the implementing org list. The new logic pulls all the activity data and picks only those implementing orgs that are tied to activities which are 100% dedicated to a target country.